### PR TITLE
Fix preset dropdown text color in light mode

### DIFF
--- a/src/components/PresetManager.tsx
+++ b/src/components/PresetManager.tsx
@@ -99,7 +99,7 @@ export function PresetManager({ panelId, presets, activePresetId, onAdd }: Prese
           {isOpen && (
             <motion.div
               ref={dropdownRef}
-              className="dialkit-preset-dropdown"
+              className="dialkit-root dialkit-preset-dropdown"
               style={{ position: 'fixed', top: pos.top, left: pos.left, minWidth: pos.width }}
               initial={{ opacity: 0, y: 4, scale: 0.97 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}


### PR DESCRIPTION
The preset dropdown is portaled outside the DialKit root, so it was missing theme CSS variables. Dropdown items were nearly invisible in light mode. Adding `dialkit-root` class to the portal container fixes this.

### Before
<img width="552" height="464" alt="image" src="https://github.com/user-attachments/assets/0f6696ce-4a87-4135-9ed0-8f8e2557c93a" />


### After
<img width="552" height="464" alt="image" src="https://github.com/user-attachments/assets/e00ae181-731d-4426-b12b-e9c9854859e8" />