### PR TITLE
feat(dialkit): respect explicit step values in Slider component

### DIFF
--- a/src/hooks/useDialKit.ts
+++ b/src/hooks/useDialKit.ts
@@ -51,7 +51,7 @@ function buildResolvedValues(
   for (const [key, configValue] of Object.entries(config)) {
     const path = prefix ? `${prefix}.${key}` : key;
 
-    if (Array.isArray(configValue) && configValue.length === 3 && typeof configValue[0] === 'number') {
+    if (Array.isArray(configValue) && configValue.length <= 4 && typeof configValue[0] === 'number') {
       // Range tuple
       result[key] = flatValues[path] ?? configValue[0];
     } else if (typeof configValue === 'number' || typeof configValue === 'boolean' || typeof configValue === 'string') {

--- a/src/store/DialStore.ts
+++ b/src/store/DialStore.ts
@@ -34,11 +34,11 @@ export type TextConfig = {
 export type DialValue = number | boolean | string | SpringConfig | ActionConfig | SelectConfig | ColorConfig | TextConfig;
 
 export type DialConfig = {
-  [key: string]: DialValue | [number, number, number] | DialConfig;
+  [key: string]: DialValue | [number, number, number, number?] | DialConfig;
 };
 
 export type ResolvedValues<T extends DialConfig> = {
-  [K in keyof T]: T[K] extends [number, number, number]
+  [K in keyof T]: T[K] extends [number, number, number, number?]
     ? number
     : T[K] extends SpringConfig
       ? SpringConfig
@@ -288,7 +288,7 @@ class DialStoreClass {
       const path = prefix ? `${prefix}.${key}` : key;
       const label = this.formatLabel(key);
 
-      if (Array.isArray(value) && value.length === 3 && typeof value[0] === 'number') {
+      if (Array.isArray(value) && value.length <= 4 && typeof value[0] === 'number') {
         // Range tuple: [default, min, max]
         controls.push({
           type: 'slider',
@@ -296,7 +296,7 @@ class DialStoreClass {
           label,
           min: value[1],
           max: value[2],
-          step: this.inferStep(value[1], value[2]),
+          step: value[3] ?? this.inferStep(value[1], value[2]),
         });
       } else if (typeof value === 'number') {
         // Single number - auto-infer range
@@ -341,7 +341,7 @@ class DialStoreClass {
     for (const [key, value] of Object.entries(config)) {
       const path = prefix ? `${prefix}.${key}` : key;
 
-      if (Array.isArray(value) && value.length === 3 && typeof value[0] === 'number') {
+      if (Array.isArray(value) && value.length <= 4 && typeof value[0] === 'number') {
         values[path] = value[0]; // Default value
       } else if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'string') {
         values[path] = value;


### PR DESCRIPTION
### Slider: discrete step support

The `dialkit` Slider previously inferred rounding behavior from the range and did not allow the user to supply a `step` prop for snapping and tick marks. This feature adds discrete step support while preserving the original continuous slider UX.

**Changes**

- **`roundValue`** — snap to nearest step multiple (`Math.round(val / step) * step`) instead of fixed 0/2 decimal rounding. Backward-compatible: `step=0.01` produces identical results to the old 2-decimal round.
- **Click snapping** — when the range has `≤20` discrete steps, clicks snap to the nearest step boundary. Fine-grained sliders (>20 steps) retain the original decile-magnetic snap behavior.
- **Hash marks** — generated at step intervals for discrete sliders (≤20 steps). Continuous sliders keep the original 9 decile marks.

**Backward compatibility**

All changes are gated on a `discreteSteps ≤ 20` threshold. Sliders using the default `step=0.01` are unaffected in behavior.

** Original behavior**

```ts
 const params = useDialKit('grid-layout', {
    columns: [6, 2, 12],
    rowHeight: 205,
});
```

<img width="561" height="387" alt="Screenshot 2026-02-14 at 1 31 22 PM" src="https://github.com/user-attachments/assets/e5c03f9d-115d-45ef-991c-165034e30f6c" />

** New behavior**

```ts
 const params = useDialKit('grid-layout', {
    columns: [6, 2, 12, 2], // New explicit step behavior (column count must be an integer)
    rowHeight: 205,
});
```

<img width="562" height="390" alt="Screenshot 2026-02-14 at 1 32 44 PM" src="https://github.com/user-attachments/assets/59099b00-1a68-45d1-bd22-64ab2098aa53" />

