### PR TITLE
Adding monitor control with setParams for updating values and optimize unnecessary re-renders

### DIFF
--- a/src/components/ControlWrapper.tsx
+++ b/src/components/ControlWrapper.tsx
@@ -1,0 +1,18 @@
+import { memo, useSyncExternalStore } from 'react';
+import { DialStore, ControlMeta, DialValue } from '../store/DialStore';
+
+interface ControlWrapperProps {
+    panelId: string;
+    control: ControlMeta;
+    renderControl: (control: ControlMeta, value: DialValue | undefined) => React.ReactNode;
+}
+
+export const ControlWrapper = memo(function ControlWrapper({ panelId, control, renderControl }: ControlWrapperProps) {
+    const value = useSyncExternalStore(
+        (cb) => DialStore.subscribePath(panelId, control.path, cb),
+        () => DialStore.getValueSnapshot(panelId, control.path),
+        () => DialStore.getValueSnapshot(panelId, control.path)
+    );
+
+    return renderControl(control, value);
+});

--- a/src/components/MonitorControl.tsx
+++ b/src/components/MonitorControl.tsx
@@ -1,0 +1,15 @@
+interface MonitorControlProps {
+    label: string;
+    value: string | number | boolean | undefined;
+}
+
+export function MonitorControl({ label, value }: MonitorControlProps) {
+    const displayValue = value === undefined ? '–' : String(value);
+
+    return (
+        <div className="dialkit-monitor-control">
+            <span className="dialkit-monitor-label">{label}</span>
+            <span className="dialkit-monitor-value">{displayValue}</span>
+        </div>
+    );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Main hook
 export { useDialKit } from './hooks/useDialKit';
-export type { UseDialOptions } from './hooks/useDialKit';
+export type { UseDialOptions, UseDialResult } from './hooks/useDialKit';
 
 // Root component (user mounts once)
 export { DialRoot } from './components/DialRoot';
@@ -16,6 +16,7 @@ export { SpringVisualization } from './components/SpringVisualization';
 export { TextControl } from './components/TextControl';
 export { SelectControl } from './components/SelectControl';
 export { ColorControl } from './components/ColorControl';
+export { MonitorControl } from './components/MonitorControl';
 export { PresetManager } from './components/PresetManager';
 
 // Store (for advanced usage)
@@ -26,6 +27,7 @@ export type {
   SelectConfig,
   ColorConfig,
   TextConfig,
+  MonitorConfig,
   Preset,
   DialValue,
   DialConfig,

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -6,9 +6,12 @@
   --dial-surface-active: rgba(255, 255, 255, 0.11);
 
   /* Text hierarchy - 3 levels */
-  --dial-text-root: #FFFFFF;   /* Root title */
-  --dial-text-section: rgba(255, 255, 255, 0.7); /* Section titles + carets */
-  --dial-text-label: rgba(255, 255, 255, 0.7);   /* Input labels */
+  --dial-text-root: #FFFFFF;
+  /* Root title */
+  --dial-text-section: rgba(255, 255, 255, 0.7);
+  /* Section titles + carets */
+  --dial-text-label: rgba(255, 255, 255, 0.7);
+  /* Input labels */
 
   /* Legacy aliases */
   --dial-text-primary: rgba(255, 255, 255, 0.95);
@@ -225,24 +228,24 @@
 }
 
 /* Adjacent non-root folders collapse gap and share a single divider */
-.dialkit-folder:not(.dialkit-folder-root) + .dialkit-folder:not(.dialkit-folder-root) {
+.dialkit-folder:not(.dialkit-folder-root)+.dialkit-folder:not(.dialkit-folder-root) {
   margin-top: -10px;
   border-top: none;
 }
 
 /* Non-root folder header - match row height */
-.dialkit-folder:not(.dialkit-folder-root) > .dialkit-folder-header {
+.dialkit-folder:not(.dialkit-folder-root)>.dialkit-folder-header {
   height: var(--dial-row-height);
   padding: 0;
 }
 
-.dialkit-folder:not(.dialkit-folder-root) > .dialkit-folder-header > .dialkit-folder-header-top {
+.dialkit-folder:not(.dialkit-folder-root)>.dialkit-folder-header>.dialkit-folder-header-top {
   padding: 0;
   height: 100%;
 }
 
 /* Root folder inner needs no extra bottom padding */
-.dialkit-folder-root > .dialkit-folder-content > .dialkit-folder-inner {
+.dialkit-folder-root>.dialkit-folder-content>.dialkit-folder-inner {
   padding-bottom: 0;
 }
 
@@ -671,6 +674,36 @@
 
 .dialkit-text-input::placeholder {
   color: var(--dial-text-tertiary);
+}
+
+/* Monitor Control (read-only value display) */
+.dialkit-monitor-control {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  height: var(--dial-row-height);
+  padding: 0 12px;
+  border-radius: var(--dial-radius);
+}
+
+.dialkit-monitor-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--dial-text-label);
+  flex-shrink: 0;
+}
+
+.dialkit-monitor-value {
+  font-size: 13px;
+  font-weight: 500;
+  font-family: ui-monospace, 'SF Mono', 'Courier New', monospace;
+  color: var(--dial-text-label);
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
 }
 
 /* Select Control - Full-width row */


### PR DESCRIPTION
Hello there 👋

I’ve been testing out DialKit and I really like using it. While working with it, I felt like I was missing the ability to have read-only values with a setter for certain params that I want to watch.

This would allow to use it not only for tweaking the UI, but also for debugging while building. 

I also ran into some performance issues related to unnecessary re-renders, so I tried to improve that as part of this PR.

What I’ve done

- Add MonitorControl component for value inspection
- Add setParams for updating values
- Refactor DialStore to use more granular subscriptions
- Reduce unnecessary re-renders

Demo
![after](https://github.com/user-attachments/assets/f9950b1b-1d85-48cc-a813-5deab23b7d17)
