### PR TITLE
Fix select dropdown clipping in nested folders

### DIFF
--- a/src/components/SelectControl.tsx
+++ b/src/components/SelectControl.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
+import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
 
 type SelectOption = string | { value: string; label: string };
@@ -20,77 +21,156 @@ function normalizeOptions(options: SelectOption[]): { value: string; label: stri
   );
 }
 
+const OPTION_HEIGHT_PX = 33; // must match .dialkit-select-option height in theme.css
+const DROPDOWN_PADDING_PX = 8; // 4px top + 4px bottom
+const DROPDOWN_MAX_HEIGHT_PX = 240;
+
 export function SelectControl({ label, value, options, onChange }: SelectControlProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const normalized = normalizeOptions(options);
+  const [mounted, setMounted] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [placement, setPlacement] = useState<'below' | 'above'>('below');
+  const [pos, setPos] = useState({ top: 0, bottom: 0, left: 0, width: 0 });
+  const normalized = useMemo(() => normalizeOptions(options), [options]);
   const selectedOption = normalized.find((o) => o.value === value);
 
-  // Close on click outside
+  const calculatePosition = useCallback(() => {
+    const rect = triggerRef.current?.getBoundingClientRect();
+    if (!rect) return;
+
+    const gap = 4;
+    const dropdownEstimatedHeight = Math.min(
+      normalized.length * OPTION_HEIGHT_PX + DROPDOWN_PADDING_PX,
+      DROPDOWN_MAX_HEIGHT_PX
+    );
+    const spaceBelow = window.innerHeight - rect.bottom - gap;
+    const spaceAbove = rect.top - gap;
+    const openBelow = spaceBelow >= dropdownEstimatedHeight || spaceBelow >= spaceAbove;
+
+    setPlacement(openBelow ? 'below' : 'above');
+    setPos({
+      top: rect.bottom + gap,
+      bottom: window.innerHeight - rect.top + gap,
+      left: rect.left,
+      width: rect.width,
+    });
+  }, [normalized.length]);
+
+  const close = useCallback(() => setIsOpen(false), []);
+
+  const open = useCallback(() => {
+    calculatePosition();
+    setIsOpen(true);
+  }, [calculatePosition]);
+
+  const toggle = useCallback(() => {
+    if (isOpen) close();
+    else open();
+  }, [isOpen, open, close]);
+
+  useEffect(() => { setMounted(true); }, []);
+
   useEffect(() => {
     if (!isOpen) return;
 
-    const handleClick = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-      }
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        dropdownRef.current?.contains(target)
+      ) return;
+      close();
     };
 
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [isOpen]);
+    const handleScroll = (e: Event) => {
+      if (dropdownRef.current?.contains(e.target as Node)) return;
+      close();
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    window.addEventListener('scroll', handleScroll, true);
+    window.addEventListener('resize', close);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      window.removeEventListener('scroll', handleScroll, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [isOpen, close]);
 
   return (
-    <div ref={containerRef} className="dialkit-select-row">
-      <button
-        className="dialkit-select-trigger"
-        onClick={() => setIsOpen(!isOpen)}
-        data-open={String(isOpen)}
-      >
-        <span className="dialkit-select-label">{label}</span>
-        <div className="dialkit-select-right">
-          <span className="dialkit-select-value">{selectedOption?.label ?? value}</span>
-          <motion.svg
-            className="dialkit-select-chevron"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            animate={{ rotate: isOpen ? 180 : 0 }}
-            transition={{ type: 'spring', visualDuration: 0.2, bounce: 0.15 }}
-          >
-            <path d="M6 9.5L12 15.5L18 9.5" />
-          </motion.svg>
-        </div>
-      </button>
+    <>
+      <div className="dialkit-select-row">
+        <button
+          ref={triggerRef}
+          className="dialkit-select-trigger"
+          onClick={toggle}
+          data-open={String(isOpen)}
+        >
+          <span className="dialkit-select-label">{label}</span>
+          <div className="dialkit-select-right">
+            <span className="dialkit-select-value">{selectedOption?.label ?? value}</span>
+            <motion.svg
+              className="dialkit-select-chevron"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              animate={{ rotate: isOpen ? 180 : 0 }}
+              transition={{ type: 'spring', visualDuration: 0.2, bounce: 0.15 }}
+            >
+              <path d="M6 9.5L12 15.5L18 9.5" />
+            </motion.svg>
+          </div>
+        </button>
+      </div>
 
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            className="dialkit-select-dropdown"
-            initial={{ opacity: 0, y: -8, scale: 0.95 }}
-            animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: -8, scale: 0.95 }}
-            transition={{ type: 'spring', visualDuration: 0.15, bounce: 0 }}
-          >
-            {normalized.map((option) => (
-              <button
-                key={option.value}
-                className="dialkit-select-option"
-                data-selected={String(option.value === value)}
-                onClick={() => {
-                  onChange(option.value);
-                  setIsOpen(false);
-                }}
-              >
-                {option.label}
-              </button>
-            ))}
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
+      {mounted && createPortal(
+        <AnimatePresence>
+          {isOpen && (
+            <motion.div
+              ref={dropdownRef}
+              className="dialkit-select-dropdown"
+              style={
+                placement === 'below'
+                  ? { position: 'fixed', top: pos.top, left: pos.left, width: pos.width }
+                  : { position: 'fixed', bottom: pos.bottom, left: pos.left, width: pos.width }
+              }
+              initial={{
+                opacity: 0,
+                y: placement === 'below' ? 4 : -4,
+                scale: 0.97,
+              }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{
+                opacity: 0,
+                y: placement === 'below' ? 4 : -4,
+                scale: 0.97,
+                pointerEvents: 'none' as any,
+              }}
+              transition={{ type: 'spring', visualDuration: 0.15, bounce: 0 }}
+            >
+              {normalized.map((option) => (
+                <button
+                  key={option.value}
+                  className="dialkit-select-option"
+                  data-selected={String(option.value === value)}
+                  onClick={() => {
+                    onChange(option.value);
+                    close();
+                  }}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>,
+        document.body
+      )}
+    </>
   );
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -738,21 +738,27 @@
 
 /* Select Dropdown */
 .dialkit-select-dropdown {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  right: 0;
   background: var(--dial-glass-bg);
   border: 1px solid var(--dial-border);
   border-radius: var(--dial-radius);
   padding: 4px;
-  z-index: 100;
+  z-index: 10000;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  max-height: 240px;
+  overflow-y: auto;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.dialkit-select-dropdown::-webkit-scrollbar {
+  display: none;
 }
 
 .dialkit-select-option {
   display: block;
   width: 100%;
+  height: 33px;
+  box-sizing: border-box;
   padding: 8px 10px;
   font-family: inherit;
   font-size: 13px;


### PR DESCRIPTION
## Summary

I ran into this issue while using DialKit with nested folders — when a `select` control sits near the bottom of a folder or the panel itself, opening the dropdown would get cut off. The options just disappear behind the folder's clip-path animation boundary or the panel's scroll container.

Dug into it and realized the dropdown was rendering inline (absolute positioned inside the select row), so it was trapped inside two clipping ancestors. The preset dropdown (`PresetManager`) already solves this exact problem by portaling to `document.body` — so I followed the same pattern here.

**What this does:**
- Portals the select dropdown to `document.body` (escapes all overflow/clip-path containers)
- Adds flip logic — measures viewport space and opens upward when there's not enough room below
- Closes on scroll/resize so the dropdown doesn't float detached from its trigger
- Adds `max-height` + `overflow-y` as a safety net for long option lists
- Bumps z-index to 10000 to match the preset dropdown layer

No changes to `Folder.tsx` — the `clipPath` is still needed for smooth height animations, the portal just sidesteps it entirely.

Fixes #4

## Test plan
- [ ] Open a select near the bottom of the panel — should flip upward
- [ ] Open a select inside a nested folder — should not clip
- [ ] Click outside the dropdown — should dismiss
- [ ] Scroll the panel while dropdown is open — should dismiss
- [ ] Resize window while dropdown is open — should dismiss
- [ ] Try with a long options list — should scroll within max-height
- [ ] Test all 4 panel positions (top-right, top-left, bottom-right, bottom-left)

🤖 Generated with [Claude Code](https://claude.com/claude-code)