### PR TITLE
Support dynamic config updates and nested action buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ const p = useDialKit('Controls', {
 ```
 
 Action buttons trigger callbacks without storing any value. The `label` defaults to the formatted key name (camelCase becomes Title Case). Multiple adjacent actions are grouped vertically.
+Action buttons can be placed at the root or nested inside folders.
 
 ### Folder
 
@@ -232,6 +233,8 @@ shadow: {
   opacity: [0.25, 0, 1],
 }
 ```
+
+DialKit also supports dynamic config updates. If your config shape, defaults, options, or labels change over time, the panel updates while preserving current values where paths still exist.
 
 ---
 

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -127,21 +127,8 @@ Apply these values as the new defaults in the useDialKit call.`;
           />
         );
 
-      default:
-        return null;
-    }
-  };
-
-  // Group consecutive actions together
-  const renderControls = () => {
-    const result: React.ReactNode[] = [];
-    let i = 0;
-
-    while (i < panel.controls.length) {
-      const control = panel.controls[i];
-
-      if (control.type === 'action') {
-        result.push(
+      case 'action':
+        return (
           <button
             key={control.path}
             className="dialkit-button"
@@ -150,14 +137,14 @@ Apply these values as the new defaults in the useDialKit call.`;
             {control.label}
           </button>
         );
-      } else {
-        result.push(renderControl(control));
-      }
 
-      i++;
+      default:
+        return null;
     }
+  };
 
-    return result;
+  const renderControls = () => {
+    return panel.controls.map(renderControl);
   };
 
   const iconTransition = { type: 'spring' as const, visualDuration: 0.4, bounce: 0.1 };

--- a/src/hooks/useDialKit.ts
+++ b/src/hooks/useDialKit.ts
@@ -12,15 +12,19 @@ export function useDialKit<T extends DialConfig>(
 ): ResolvedValues<T> {
   const instanceId = useId();
   const panelId = `${name}-${instanceId}`;
-  const configRef = useRef(config);
   const onActionRef = useRef(options?.onAction);
   onActionRef.current = options?.onAction;
 
   // Register panel on mount
   useEffect(() => {
-    DialStore.registerPanel(panelId, name, configRef.current);
+    DialStore.registerPanel(panelId, name, config);
     return () => DialStore.unregisterPanel(panelId);
-  }, [panelId, name]);
+  }, [panelId]);
+
+  // Keep panel metadata and controls in sync with config/name changes.
+  useEffect(() => {
+    DialStore.updatePanel(panelId, name, config);
+  }, [panelId, name, config]);
 
   // Subscribe to action events
   useEffect(() => {

--- a/src/store/DialStore.ts
+++ b/src/store/DialStore.ts
@@ -94,14 +94,72 @@ class DialStoreClass {
   private presets: Map<string, Preset[]> = new Map();
   private activePreset: Map<string, string | null> = new Map();
   private baseValues: Map<string, Record<string, DialValue>> = new Map();
+  private configSignatures: Map<string, string> = new Map();
 
   registerPanel(id: string, name: string, config: DialConfig): void {
     const controls = this.parseConfig(config, '');
     const values = this.flattenValues(config, '');
+    const signature = this.serializeConfig(config);
 
     this.panels.set(id, { id, name, controls, values });
     this.snapshots.set(id, { ...values });
     this.baseValues.set(id, { ...values });
+    this.configSignatures.set(id, signature);
+    this.notifyGlobal();
+  }
+
+  updatePanel(id: string, name: string, config: DialConfig): void {
+    const existing = this.panels.get(id);
+    if (!existing) {
+      this.registerPanel(id, name, config);
+      return;
+    }
+
+    const signature = this.serializeConfig(config);
+    const previousSignature = this.configSignatures.get(id);
+    if (existing.name === name && previousSignature === signature) {
+      return;
+    }
+
+    const controls = this.parseConfig(config, '');
+    const defaultValues = this.flattenValues(config, '');
+    const nextValues: Record<string, DialValue> = {};
+
+    for (const [path, defaultValue] of Object.entries(defaultValues)) {
+      if (path in existing.values) {
+        nextValues[path] = existing.values[path];
+      } else {
+        nextValues[path] = defaultValue;
+      }
+    }
+
+    for (const [path, mode] of Object.entries(existing.values)) {
+      if (!path.endsWith('.__mode')) {
+        continue;
+      }
+      const springPath = path.slice(0, -'__mode'.length - 1);
+      if (springPath in defaultValues) {
+        nextValues[path] = mode;
+      }
+    }
+
+    const nextPanel: PanelConfig = { id, name, controls, values: nextValues };
+    this.panels.set(id, nextPanel);
+    this.snapshots.set(id, { ...nextValues });
+
+    const previousBaseValues = this.baseValues.get(id) ?? {};
+    const nextBaseValues: Record<string, DialValue> = {};
+    for (const [path, defaultValue] of Object.entries(defaultValues)) {
+      if (path in previousBaseValues) {
+        nextBaseValues[path] = previousBaseValues[path];
+      } else {
+        nextBaseValues[path] = defaultValue;
+      }
+    }
+    this.baseValues.set(id, nextBaseValues);
+
+    this.configSignatures.set(id, signature);
+    this.notify(id);
     this.notifyGlobal();
   }
 
@@ -109,6 +167,9 @@ class DialStoreClass {
     this.panels.delete(id);
     this.listeners.delete(id);
     this.snapshots.delete(id);
+    this.actionListeners.delete(id);
+    this.baseValues.delete(id);
+    this.configSignatures.delete(id);
     this.notifyGlobal();
   }
 
@@ -453,6 +514,22 @@ class DialStoreClass {
     if (range <= 10) return 0.1;
     if (range <= 100) return 1;
     return 10;
+  }
+
+  private serializeConfig(config: DialConfig): string {
+    const sortObject = (value: unknown): unknown => {
+      if (Array.isArray(value)) {
+        return value.map(sortObject);
+      }
+      if (value && typeof value === 'object') {
+        const sortedEntries = Object.entries(value as Record<string, unknown>)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([key, nested]) => [key, sortObject(nested)]);
+        return Object.fromEntries(sortedEntries);
+      }
+      return value;
+    };
+    return JSON.stringify(sortObject(config));
   }
 }
 


### PR DESCRIPTION
## Summary
- add `DialStore.updatePanel(...)` and wire `useDialKit` to call it so panels react when config/name changes
- preserve existing values (and spring mode state) for unchanged paths when config shape updates
- render `action` controls uniformly (including inside nested folders), not only at root level
- update README to document nested action buttons and dynamic config updates

## Why
In real apps the config object often changes over time (dynamic select options, status readouts, conditional controls). Current behavior only registers config once on mount, which leaves controls stale. Also, action buttons in nested folders are parsed but not rendered.

## Validation
- `npm run typecheck`
- `npm run build`

Both pass with these changes.
