### PR TITLE
Add Solid support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,473 @@
 {
   "name": "dialkit",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dialkit",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
-      "dependencies": {
-        "dialkit": "^0.1.1"
-      },
       "devDependencies": {
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
+        "esbuild-plugin-solid": "^0.6.0",
         "motion": "^12.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "solid-js": "^1.9.0",
         "tsup": "^8.0.0",
         "typescript": "^5.3.0"
       },
       "peerDependencies": {
         "motion": ">=11.0.0",
         "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
+        "react-dom": ">=18.0.0",
+        "solid-js": ">=1.6.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-annotate-as-pure": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-create-class-features-plugin": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/helper-replace-supers": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/traverse": "^7.28.6",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-member-expression-to-functions": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.5",
+        "@babel/types": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-optimise-call-expression": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-replace-supers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-member-expression-to-functions": "^7.28.5",
+        "@babel/helper-optimise-call-expression": "^7.27.1",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.3",
+        "@babel/helper-create-class-features-plugin": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -479,6 +923,17 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -912,6 +1367,102 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/babel-plugin-jsx-dom-expressions": {
+      "version": "0.40.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.40.5.tgz",
+      "integrity": "sha512-8TFKemVLDYezqqv4mWz+PhRrkryTzivTGu0twyLrOkVZ0P63COx2Y04eVsUjFlwSOXui1z3P3Pn209dokWnirg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "7.18.6",
+        "@babel/plugin-syntax-jsx": "^7.18.6",
+        "@babel/types": "^7.20.7",
+        "html-entities": "2.3.3",
+        "parse5": "^7.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.20.12"
+      }
+    },
+    "node_modules/babel-plugin-jsx-dom-expressions/node_modules/@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/babel-preset-solid": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.9.10.tgz",
+      "integrity": "sha512-HCelrgua/Y+kqO8RyL04JBWS/cVdrtUv/h45GntgQY+cJl4eBcKkCDV3TdMjtKx1nXwRaR9QXslM/Npm1dxdZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jsx-dom-expressions": "^0.40.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "solid-js": "^1.9.10"
+      },
+      "peerDependenciesMeta": {
+        "solid-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
+      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -937,6 +1488,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001774",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
+      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -981,6 +1553,13 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1006,15 +1585,24 @@
         }
       }
     },
-    "node_modules/dialkit": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dialkit/-/dialkit-0.1.1.tgz",
-      "integrity": "sha512-95OMqxKske5FhV4v5bxrFy0ZiesAoRgJyHUXk3XEIxY+Xxz6YjvVKzgzstRRKVR/G2VkxJzja7jpIsEUDCKcqQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "motion": ">=11.0.0",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0"
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.302",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
+      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/esbuild": {
@@ -1059,6 +1647,32 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
+    "node_modules/esbuild-plugin-solid": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/esbuild-plugin-solid/-/esbuild-plugin-solid-0.6.0.tgz",
+      "integrity": "sha512-V1FvDALwLDX6K0XNYM9CMRAnMzA0+Ecu55qBUT9q/eAJh1KIDsTMFoOzMSgyHqbOfvrVfO3Mws3z7TW2GVnIZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.20.12",
+        "@babel/preset-typescript": "^7.18.6",
+        "babel-preset-solid": "^1.6.9"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.20",
+        "solid-js": ">= 1.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1093,6 +1707,7 @@
       "version": "12.29.0",
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.29.0.tgz",
       "integrity": "sha512-1gEFGXHYV2BD42ZPTFmSU9buehppU+bCuOnHU0AD18DKh9j4DuTx47MvqY5ax+NNWRtK32qIcJf1UxKo1WwjWg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "motion-dom": "^12.29.0",
@@ -1131,6 +1746,23 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.3.tgz",
+      "integrity": "sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -1145,7 +1777,34 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -1181,12 +1840,23 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/magic-string": {
@@ -1216,6 +1886,7 @@
       "version": "12.29.0",
       "resolved": "https://registry.npmjs.org/motion/-/motion-12.29.0.tgz",
       "integrity": "sha512-rjB5CP2N9S2ESAyEFnAFMgTec6X8yvfxLNcz8n12gPq3M48R7ZbBeVYkDOTj8SPMwfvGIFI801SiPSr1+HCr9g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "framer-motion": "^12.29.0",
@@ -1242,6 +1913,7 @@
       "version": "12.29.0",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.29.0.tgz",
       "integrity": "sha512-3eiz9bb32yvY8Q6XNM4AwkSOBPgU//EIKTZwsSWgA9uzbPBhZJeScCVcBuwwYVqhfamewpv7ZNmVKTGp5qnzkA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.27.2"
@@ -1251,6 +1923,7 @@
       "version": "12.27.2",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.27.2.tgz",
       "integrity": "sha512-B55gcoL85Mcdt2IEStY5EEAsrMSVE2sI14xQ/uAdPL+mfQxhKKFaEag9JmfxedJOR4vZpBGoPeC/Gm13I/4g5Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -1272,6 +1945,13 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/node-releases": {
+      "version": "2.0.27",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
+      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1280,6 +1960,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -1378,6 +2071,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -1390,6 +2084,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -1472,9 +2167,55 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/seroval": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
+      "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/seroval-plugins": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.0.tgz",
+      "integrity": "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "seroval": "^1.0"
+      }
+    },
+    "node_modules/solid-js": {
+      "version": "1.9.11",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.11.tgz",
+      "integrity": "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.0",
+        "seroval": "~1.5.0",
+        "seroval-plugins": "~1.5.0"
       }
     },
     "node_modules/source-map": {
@@ -1578,6 +2319,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsup": {
@@ -1653,6 +2395,44 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dialkit",
   "version": "0.2.2",
-  "description": "Real-time parameter tweaking for React apps",
+  "description": "Real-time parameter tweaking for React and Solid apps",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
@@ -17,6 +17,16 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./solid": {
+      "import": {
+        "types": "./dist/solid/index.d.ts",
+        "default": "./dist/solid/index.js"
+      },
+      "require": {
+        "types": "./dist/solid/index.d.cts",
+        "default": "./dist/solid/index.cjs"
+      }
+    },
     "./styles.css": "./dist/styles.css"
   },
   "files": [
@@ -25,36 +35,48 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.solid.json"
   },
   "peerDependencies": {
     "motion": ">=11.0.0",
     "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react-dom": ">=18.0.0",
+    "solid-js": ">=1.6.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "solid-js": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "esbuild-plugin-solid": "^0.6.0",
     "motion": "^12.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "solid-js": "^1.9.0",
     "tsup": "^8.0.0",
     "typescript": "^5.3.0"
   },
   "keywords": [
     "react",
+    "solid",
+    "solidjs",
     "animation",
     "tweaking",
     "parameters",
-    "devtools",
-    "framer-motion"
+    "devtools"
   ],
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/joshpuckett/dialkit"
-  },
-  "dependencies": {
-    "dialkit": "^0.1.1"
   }
 }

--- a/src/solid/components/ButtonGroup.tsx
+++ b/src/solid/components/ButtonGroup.tsx
@@ -1,0 +1,22 @@
+import { For } from 'solid-js';
+
+interface ButtonGroupProps {
+  buttons: Array<{
+    label: string;
+    onClick: () => void;
+  }>;
+}
+
+export function ButtonGroup(props: ButtonGroupProps) {
+  return (
+    <div class="dialkit-button-group">
+      <For each={props.buttons}>
+        {(button) => (
+          <button class="dialkit-button" onClick={button.onClick}>
+            {button.label}
+          </button>
+        )}
+      </For>
+    </div>
+  );
+}

--- a/src/solid/components/ColorControl.tsx
+++ b/src/solid/components/ColorControl.tsx
@@ -1,0 +1,87 @@
+import { createSignal, createEffect, createUniqueId, Show } from 'solid-js';
+
+interface ColorControlProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const HEX_COLOR_REGEX = /^#([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
+
+function expandShorthandHex(hex: string): string {
+  if (hex.length !== 4) return hex;
+  return `#${hex[1]}${hex[1]}${hex[2]}${hex[2]}${hex[3]}${hex[3]}`;
+}
+
+export function ColorControl(props: ColorControlProps) {
+  const [isEditing, setIsEditing] = createSignal(false);
+  const [editValue, setEditValue] = createSignal(props.value);
+  const textInputId = createUniqueId();
+  let colorInputRef!: HTMLInputElement;
+
+  // Sync editValue when value changes externally
+  createEffect(() => {
+    if (!isEditing()) {
+      setEditValue(props.value);
+    }
+  });
+
+  const handleTextSubmit = () => {
+    setIsEditing(false);
+    if (HEX_COLOR_REGEX.test(editValue())) {
+      props.onChange(editValue());
+    } else {
+      setEditValue(props.value);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') handleTextSubmit();
+    else if (e.key === 'Escape') {
+      setIsEditing(false);
+      setEditValue(props.value);
+    }
+  };
+
+  return (
+    <div class="dialkit-color-control">
+      <label class="dialkit-color-label" for={textInputId}>{props.label}</label>
+      <div class="dialkit-color-inputs">
+        <Show
+          when={isEditing()}
+          fallback={
+            <span class="dialkit-color-hex" onClick={() => setIsEditing(true)}>
+              {(props.value ?? '').toUpperCase()}
+            </span>
+          }
+        >
+          <input
+            id={textInputId}
+            type="text"
+            class="dialkit-color-hex-input"
+            value={editValue()}
+            onInput={(e) => setEditValue(e.currentTarget.value)}
+            onBlur={handleTextSubmit}
+            onKeyDown={handleKeyDown}
+            autofocus
+          />
+        </Show>
+        <button
+          class="dialkit-color-swatch"
+          style={{ 'background-color': props.value }}
+          onClick={() => colorInputRef?.click()}
+          title="Pick color"
+          aria-label={`Pick color for ${props.label}`}
+        />
+        <input
+          ref={colorInputRef}
+          type="color"
+          class="dialkit-color-picker-native"
+          aria-label={`${props.label} color picker`}
+          value={props.value.length === 4 ? expandShorthandHex(props.value) : props.value.slice(0, 7)}
+          onInput={(e) => props.onChange(e.currentTarget.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/solid/components/DialRoot.tsx
+++ b/src/solid/components/DialRoot.tsx
@@ -1,0 +1,39 @@
+import { createSignal, onMount, onCleanup, Show, For } from 'solid-js';
+import { Portal } from 'solid-js/web';
+import { DialStore } from '../../store/DialStore';
+import type { PanelConfig } from '../../store/DialStore';
+import { Panel } from './Panel';
+
+export type DialPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+
+interface DialRootProps {
+  position?: DialPosition;
+}
+
+export function DialRoot(props: DialRootProps) {
+  const [panels, setPanels] = createSignal<PanelConfig[]>([]);
+  const [mounted, setMounted] = createSignal(false);
+
+  onMount(() => {
+    setMounted(true);
+    setPanels(DialStore.getPanels());
+    const unsub = DialStore.subscribeGlobal(() => {
+      setPanels(DialStore.getPanels());
+    });
+    onCleanup(unsub);
+  });
+
+  return (
+    <Show when={mounted() && typeof window !== 'undefined' && panels().length > 0}>
+      <Portal mount={document.body}>
+        <div class="dialkit-root">
+          <div class="dialkit-panel" data-position={props.position ?? 'top-right'}>
+            <For each={panels()}>
+              {(panel) => <Panel panel={panel} />}
+            </For>
+          </div>
+        </div>
+      </Portal>
+    </Show>
+  );
+}

--- a/src/solid/components/Folder.tsx
+++ b/src/solid/components/Folder.tsx
@@ -1,0 +1,311 @@
+import { createSignal, createEffect, onCleanup, Show, JSX } from 'solid-js';
+import { animate } from 'motion';
+
+interface FolderProps {
+  title: string;
+  children: JSX.Element;
+  defaultOpen?: boolean;
+  isRoot?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
+  toolbar?: JSX.Element;
+}
+
+export function Folder(props: FolderProps) {
+  const [isOpen, setIsOpen] = createSignal(props.defaultOpen ?? true);
+  const [isCollapsed, setIsCollapsed] = createSignal(!(props.defaultOpen ?? true));
+  const [contentHeight, setContentHeight] = createSignal<number | undefined>(undefined);
+
+  // Section content animation state
+  const [contentMounted, setContentMounted] = createSignal(props.defaultOpen ?? true);
+  let skipFirstAnim = props.defaultOpen ?? true;
+  let sectionContentRef: HTMLDivElement | undefined;
+  let sectionAnim: any = null;
+  let folderChevronRef: SVGSVGElement | undefined;
+  let chevronAnim: any = null;
+  let chevronInitialized = false;
+  let panelTapAnim: any = null;
+
+  let contentRef: HTMLDivElement | undefined;
+
+  // Track content height for root panel sizing
+  createEffect(() => {
+    if (!props.isRoot || !isOpen()) return;
+    const el = contentRef;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      const h = el.offsetHeight;
+      setContentHeight(prev => prev === h ? prev : h);
+    });
+    ro.observe(el);
+    onCleanup(() => ro.disconnect());
+  });
+
+  createEffect(() => {
+    if (props.isRoot || !folderChevronRef) return;
+    const open = isOpen();
+    chevronAnim?.stop();
+
+    if (!chevronInitialized) {
+      folderChevronRef.style.transform = `rotate(${open ? 0 : 180}deg)`;
+      chevronInitialized = true;
+      return;
+    }
+
+    chevronAnim = animate(
+      folderChevronRef,
+      { rotate: open ? 0 : 180 },
+      { type: 'spring', visualDuration: 0.35, bounce: 0.15 }
+    );
+
+    onCleanup(() => chevronAnim?.stop());
+  });
+
+  const handleToggle = () => {
+    const next = !isOpen();
+    setIsOpen(next);
+    if (next) {
+      setIsCollapsed(false);
+      if (!props.isRoot) {
+        sectionAnim?.stop();
+        sectionAnim = null;
+        if (sectionContentRef) {
+          // If close was interrupted, animate section back open.
+          sectionAnim = animate(
+            sectionContentRef,
+            { height: 'auto', opacity: 1 },
+            {
+              type: 'spring',
+              visualDuration: 0.35,
+              bounce: 0.1,
+              onComplete: () => {
+                sectionAnim = null;
+              },
+            }
+          );
+        } else {
+          // If fully unmounted, mount and let the ref callback run enter animation.
+          setContentMounted(true);
+        }
+      }
+    } else {
+      setIsCollapsed(true);
+      if (!props.isRoot) {
+        if (sectionContentRef) {
+          const currentHeight = sectionContentRef.getBoundingClientRect().height;
+          sectionContentRef.style.height = `${currentHeight}px`;
+          sectionAnim?.stop();
+          sectionAnim = animate(
+            sectionContentRef,
+            { height: 0, opacity: 0 },
+            {
+              type: 'spring', visualDuration: 0.35, bounce: 0.1,
+              onComplete: () => {
+                setContentMounted(false);
+                sectionAnim = null;
+                sectionContentRef = undefined;
+              },
+            }
+          );
+        } else {
+          setContentMounted(false);
+        }
+      }
+    }
+    props.onOpenChange?.(next);
+  };
+
+  const folderContent = () => (
+    <div
+      ref={(el) => { if (props.isRoot) contentRef = el; }}
+      class={`dialkit-folder ${props.isRoot ? 'dialkit-folder-root' : ''}`}
+    >
+      <div
+        class={`dialkit-folder-header ${props.isRoot ? 'dialkit-panel-header' : ''}`}
+        onClick={handleToggle}
+      >
+        <div class="dialkit-folder-header-top">
+          {props.isRoot ? (
+            <Show when={isOpen()}>
+              <div class="dialkit-folder-title-row">
+                <span class="dialkit-folder-title dialkit-folder-title-root">
+                  {props.title}
+                </span>
+              </div>
+            </Show>
+          ) : (
+            <div class="dialkit-folder-title-row">
+              <span class="dialkit-folder-title">{props.title}</span>
+            </div>
+          )}
+
+          {props.isRoot ? (
+            <svg class="dialkit-panel-icon" viewBox="0 0 16 16" fill="none">
+              <path
+                opacity="0.5"
+                d="M6.84766 11.75C6.78583 11.9899 6.75 12.2408 6.75 12.5C6.75 12.7592 6.78583 13.0101 6.84766 13.25H2C1.58579 13.25 1.25 12.9142 1.25 12.5C1.25 12.0858 1.58579 11.75 2 11.75H6.84766ZM14 11.75C14.4142 11.75 14.75 12.0858 14.75 12.5C14.75 12.9142 14.4142 13.25 14 13.25H12.6523C12.7142 13.0101 12.75 12.7592 12.75 12.5C12.75 12.2408 12.7142 11.9899 12.6523 11.75H14ZM3.09766 7.25C3.03583 7.48994 3 7.74075 3 8C3 8.25925 3.03583 8.51006 3.09766 8.75H2C1.58579 8.75 1.25 8.41421 1.25 8C1.25 7.58579 1.58579 7.25 2 7.25H3.09766ZM14 7.25C14.4142 7.25 14.75 7.58579 14.75 8C14.75 8.41421 14.4142 8.75 14 8.75H8.90234C8.96417 8.51006 9 8.25925 9 8C9 7.74075 8.96417 7.48994 8.90234 7.25H14ZM7.59766 2.75C7.53583 2.98994 7.5 3.24075 7.5 3.5C7.5 3.75925 7.53583 4.01006 7.59766 4.25H2C1.58579 4.25 1.25 3.91421 1.25 3.5C1.25 3.08579 1.58579 2.75 2 2.75H7.59766ZM14 2.75C14.4142 2.75 14.75 3.08579 14.75 3.5C14.75 3.91421 14.4142 4.25 14 4.25H13.4023C13.4642 4.01006 13.5 3.75925 13.5 3.5C13.5 3.24075 13.4642 2.98994 13.4023 2.75H14Z"
+                fill="currentColor"
+              />
+              <circle cx="6" cy="8" r="0.998596" fill="currentColor" stroke="currentColor" stroke-width="1.25" />
+              <circle cx="10.4999" cy="3.5" r="0.998657" fill="currentColor" stroke="currentColor" stroke-width="1.25" />
+              <circle cx="9.75015" cy="12.5" r="0.997986" fill="currentColor" stroke="currentColor" stroke-width="1.25" />
+            </svg>
+          ) : (
+            <svg
+              ref={folderChevronRef}
+              class="dialkit-folder-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M6 9.5L12 15.5L18 9.5" />
+            </svg>
+          )}
+        </div>
+
+        <Show when={props.isRoot && props.toolbar && isOpen()}>
+          <div class="dialkit-panel-toolbar" onClick={(e) => e.stopPropagation()}>
+            {props.toolbar}
+          </div>
+        </Show>
+      </div>
+
+      <Show when={props.isRoot ? isOpen() : contentMounted()}>
+        <div
+          ref={(el) => {
+            if (props.isRoot) return;
+            sectionContentRef = el;
+            if (skipFirstAnim) { skipFirstAnim = false; return; }
+
+            sectionAnim?.stop();
+            el.style.height = '0px';
+            el.style.opacity = '0';
+            sectionAnim = animate(
+              el,
+              { height: 'auto', opacity: 1 },
+              {
+                type: 'spring',
+                visualDuration: 0.35,
+                bounce: 0.1,
+                onComplete: () => {
+                  sectionAnim = null;
+                },
+              }
+            );
+          }}
+          class="dialkit-folder-content"
+          style={!props.isRoot ? { 'clip-path': 'inset(0 -20px)' } : undefined}
+        >
+          <div class="dialkit-folder-inner">{props.children}</div>
+        </div>
+      </Show>
+    </div>
+  );
+
+  // Root folders render inside the panel container.
+  if (props.isRoot) {
+    let panelRef!: HTMLDivElement;
+    let rootPanelAnim: any = null;
+    let rootPanelInitialized = false;
+    let lastRootOpen = isOpen();
+
+    createEffect(() => {
+      if (!panelRef || isOpen()) return;
+      const handler = (e: Event) => {
+        e.stopPropagation();
+        handleToggle();
+      };
+      panelRef.addEventListener('click', handler);
+      onCleanup(() => panelRef.removeEventListener('click', handler));
+    });
+
+    createEffect(() => {
+      if (!panelRef) return;
+
+      const open = isOpen();
+      const measuredOpenHeight = contentHeight() !== undefined
+        ? contentHeight()! + 24
+        : panelRef.getBoundingClientRect().height;
+
+      const target = {
+        width: open ? 280 : 42,
+        height: open ? measuredOpenHeight : 42,
+        borderRadius: open ? 14 : 21,
+        boxShadow: open
+          ? '0 8px 32px rgba(0, 0, 0, 0.5)'
+          : '0 4px 16px rgba(0, 0, 0, 0.25)',
+      };
+
+      panelRef.style.cursor = open ? '' : 'pointer';
+      panelRef.style.overflow = open ? '' : 'hidden';
+
+      if (!rootPanelInitialized) {
+        rootPanelInitialized = true;
+        panelRef.style.width = `${target.width}px`;
+        panelRef.style.height = `${target.height}px`;
+        panelRef.style.borderRadius = `${target.borderRadius}px`;
+        panelRef.style.boxShadow = target.boxShadow;
+        lastRootOpen = open;
+        return;
+      }
+
+      if (open !== lastRootOpen) {
+        rootPanelAnim?.stop();
+        rootPanelAnim = animate(panelRef, target, {
+          type: 'spring',
+          visualDuration: 0.15,
+          bounce: 0.3,
+          onComplete: () => {
+            rootPanelAnim = null;
+          },
+        });
+        lastRootOpen = open;
+        return;
+      }
+
+      if (open) {
+        panelRef.style.height = `${target.height}px`;
+      }
+    });
+
+    onCleanup(() => {
+      rootPanelAnim?.stop();
+      panelTapAnim?.stop();
+    });
+
+    return (
+      <div
+        ref={panelRef}
+        class="dialkit-panel-inner"
+        data-collapsed={String(isCollapsed())}
+        onPointerDown={() => {
+          if (isOpen()) return;
+          (document.activeElement as HTMLElement)?.blur?.();
+          panelTapAnim?.stop();
+          panelTapAnim = animate(panelRef, { scale: 0.9 }, { type: 'spring', visualDuration: 0.15, bounce: 0.3 });
+        }}
+        onPointerUp={() => {
+          if (isOpen()) return;
+          panelTapAnim?.stop();
+          panelTapAnim = animate(panelRef, { scale: 1 }, { type: 'spring', visualDuration: 0.15, bounce: 0.3 });
+        }}
+        onPointerCancel={() => {
+          if (isOpen()) return;
+          panelTapAnim?.stop();
+          panelTapAnim = animate(panelRef, { scale: 1 }, { type: 'spring', visualDuration: 0.15, bounce: 0.3 });
+        }}
+        onPointerLeave={() => {
+          if (isOpen()) return;
+          panelTapAnim?.stop();
+          panelTapAnim = animate(panelRef, { scale: 1 }, { type: 'spring', visualDuration: 0.15, bounce: 0.3 });
+        }}
+      >
+        {folderContent()}
+      </div>
+    );
+  }
+
+  return folderContent();
+}

--- a/src/solid/components/Panel.tsx
+++ b/src/solid/components/Panel.tsx
@@ -1,0 +1,302 @@
+import { createSignal, createEffect, onMount, onCleanup, Show, For, JSX } from 'solid-js';
+import { animate } from 'motion';
+import { DialStore } from '../../store/DialStore';
+import type { ControlMeta, PanelConfig, SpringConfig, DialValue } from '../../store/DialStore';
+import { Folder } from './Folder';
+import { Slider } from './Slider';
+import { Toggle } from './Toggle';
+import { SpringControl } from './SpringControl';
+import { TextControl } from './TextControl';
+import { SelectControl } from './SelectControl';
+import { ColorControl } from './ColorControl';
+import { PresetManager } from './PresetManager';
+
+interface PanelProps {
+  panel: PanelConfig;
+}
+
+export function Panel(props: PanelProps) {
+  const [copied, setCopied] = createSignal(false);
+  const [isPanelOpen, setIsPanelOpen] = createSignal(true);
+  const [values, setValues] = createSignal<Record<string, DialValue>>(
+    DialStore.getValues(props.panel.id)
+  );
+  const [presets, setPresets] = createSignal(DialStore.getPresets(props.panel.id));
+  const [activePresetId, setActivePresetId] = createSignal(DialStore.getActivePresetId(props.panel.id));
+  let addButtonRef!: HTMLButtonElement;
+  let copyButtonRef!: HTMLButtonElement;
+  let copyClipboardIconRef!: HTMLSpanElement;
+  let copyCheckIconRef!: HTMLSpanElement;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let addTapAnim: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let copyTapAnim: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let copyClipboardAnim: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let copyCheckAnim: any = null;
+  let didInitCopyIcons = false;
+
+  const tapTransition = { type: 'spring' as const, visualDuration: 0.15, bounce: 0.3 };
+
+  onMount(() => {
+    const unsub = DialStore.subscribe(props.panel.id, () => {
+      setValues(DialStore.getValues(props.panel.id));
+      setPresets(DialStore.getPresets(props.panel.id));
+      setActivePresetId(DialStore.getActivePresetId(props.panel.id));
+    });
+
+    if (copyClipboardIconRef && copyCheckIconRef) {
+      copyClipboardIconRef.style.transformOrigin = '50% 50%';
+      copyClipboardIconRef.style.opacity = '1';
+      copyClipboardIconRef.style.transform = 'scale(1)';
+      copyClipboardIconRef.style.filter = 'blur(0px)';
+      copyCheckIconRef.style.transformOrigin = '50% 50%';
+      copyCheckIconRef.style.opacity = '0';
+      copyCheckIconRef.style.transform = 'scale(0.5)';
+      copyCheckIconRef.style.filter = 'blur(4px)';
+      didInitCopyIcons = true;
+    }
+
+    onCleanup(unsub);
+  });
+
+  const handleAddPreset = () => {
+    const nextNum = presets().length + 2;
+    DialStore.savePreset(props.panel.id, `Version ${nextNum}`);
+  };
+
+  const handleCopy = () => {
+    const jsonStr = JSON.stringify(values(), null, 2);
+    const instruction = `Update the createDialKit configuration for "${props.panel.name}" with these values:\n\n\`\`\`json\n${jsonStr}\n\`\`\`\n\nApply these values as the new defaults in the createDialKit call.`;
+    navigator.clipboard.writeText(instruction);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  createEffect(() => {
+    const isCopied = copied();
+    if (!copyClipboardIconRef || !copyCheckIconRef) return;
+
+    copyClipboardAnim?.stop();
+    copyCheckAnim?.stop();
+
+    if (!didInitCopyIcons) return;
+
+    const transition = { type: 'spring' as const, visualDuration: 0.3, bounce: 0.2 };
+    copyClipboardAnim = animate(copyClipboardIconRef, {
+      opacity: isCopied ? 0 : 1,
+      scale: isCopied ? 0.5 : 1,
+      filter: isCopied ? 'blur(4px)' : 'blur(0px)',
+    }, transition);
+    copyCheckAnim = animate(copyCheckIconRef, {
+      opacity: isCopied ? 1 : 0,
+      scale: isCopied ? 1 : 0.5,
+      filter: isCopied ? 'blur(0px)' : 'blur(4px)',
+    }, transition);
+  });
+
+  onCleanup(() => {
+    addTapAnim?.stop();
+    copyTapAnim?.stop();
+    copyClipboardAnim?.stop();
+    copyCheckAnim?.stop();
+  });
+
+  const handleAddTapStart = () => {
+    if (!addButtonRef) return;
+    addTapAnim?.stop();
+    addTapAnim = animate(addButtonRef, { scale: 0.9 }, tapTransition);
+  };
+
+  const handleAddTapEnd = () => {
+    if (!addButtonRef) return;
+    addTapAnim?.stop();
+    addTapAnim = animate(addButtonRef, { scale: 1 }, tapTransition);
+  };
+
+  const handleCopyTapStart = () => {
+    if (!copyButtonRef) return;
+    copyTapAnim?.stop();
+    copyTapAnim = animate(copyButtonRef, { scale: 0.95 }, tapTransition);
+  };
+
+  const handleCopyTapEnd = () => {
+    if (!copyButtonRef) return;
+    copyTapAnim?.stop();
+    copyTapAnim = animate(copyButtonRef, { scale: 1 }, tapTransition);
+  };
+
+  const renderControl = (control: ControlMeta) => {
+    const value = () => values()[control.path];
+
+    switch (control.type) {
+      case 'slider':
+        return (
+          <Slider
+            label={control.label}
+            value={value() as number}
+            onChange={(v) => DialStore.updateValue(props.panel.id, control.path, v)}
+            min={control.min}
+            max={control.max}
+            step={control.step}
+          />
+        );
+
+      case 'toggle':
+        return (
+          <Toggle
+            label={control.label}
+            checked={value() as boolean}
+            onChange={(v) => DialStore.updateValue(props.panel.id, control.path, v)}
+          />
+        );
+
+      case 'spring':
+        return (
+          <SpringControl
+            panelId={props.panel.id}
+            path={control.path}
+            label={control.label}
+            spring={value() as SpringConfig}
+            onChange={(v) => DialStore.updateValue(props.panel.id, control.path, v)}
+          />
+        );
+
+      case 'folder':
+        return (
+          <Folder title={control.label} defaultOpen={control.defaultOpen ?? true}>
+            <For each={control.children ?? []}>
+              {(child) => <>{renderControl(child)}</>}
+            </For>
+          </Folder>
+        );
+
+      case 'text':
+        return (
+          <TextControl
+            label={control.label}
+            value={value() as string}
+            onChange={(v) => DialStore.updateValue(props.panel.id, control.path, v)}
+            placeholder={control.placeholder}
+          />
+        );
+
+      case 'select':
+        return (
+          <SelectControl
+            label={control.label}
+            value={value() as string}
+            options={control.options ?? []}
+            onChange={(v) => DialStore.updateValue(props.panel.id, control.path, v)}
+          />
+        );
+
+      case 'color':
+        return (
+          <ColorControl
+            label={control.label}
+            value={value() as string}
+            onChange={(v) => DialStore.updateValue(props.panel.id, control.path, v)}
+          />
+        );
+
+      default:
+        return null;
+    }
+  };
+
+  const renderControls = () => {
+    return (
+      <For each={props.panel.controls}>
+        {(control) => (
+          <>
+            {control.type === 'action' ? (
+              <button
+                class="dialkit-button"
+                onClick={() => DialStore.triggerAction(props.panel.id, control.path)}
+              >
+                {control.label}
+              </button>
+            ) : (
+              renderControl(control)
+            )}
+          </>
+        )}
+      </For>
+    );
+  };
+
+  const toolbar = (
+    <>
+      <button
+        ref={addButtonRef}
+        class="dialkit-toolbar-add"
+        onClick={handleAddPreset}
+        onPointerDown={handleAddTapStart}
+        onPointerUp={handleAddTapEnd}
+        onPointerCancel={handleAddTapEnd}
+        onPointerLeave={handleAddTapEnd}
+        title="Add preset"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M4 6H20" />
+          <path d="M4 12H10" />
+          <path d="M15 15L21 15" />
+          <path d="M18 12V18" />
+          <path d="M4 18H10" />
+        </svg>
+      </button>
+
+      <PresetManager
+        panelId={props.panel.id}
+        presets={presets()}
+        activePresetId={activePresetId()}
+        onAdd={handleAddPreset}
+      />
+
+      <button
+        ref={copyButtonRef}
+        class="dialkit-toolbar-copy"
+        onClick={handleCopy}
+        onPointerDown={handleCopyTapStart}
+        onPointerUp={handleCopyTapEnd}
+        onPointerCancel={handleCopyTapEnd}
+        onPointerLeave={handleCopyTapEnd}
+        title="Copy parameters"
+      >
+        <span class="dialkit-toolbar-copy-icon-wrap">
+          <span
+            ref={copyClipboardIconRef}
+            class="dialkit-toolbar-copy-icon"
+            style={{ opacity: 1, transform: 'scale(1)', filter: 'blur(0px)' }}
+          >
+            <svg viewBox="0 0 24 24" fill="none" width="16" height="16">
+              <path d="M8 6C8 4.34315 9.34315 3 11 3H13C14.6569 3 16 4.34315 16 6V7H8V6Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
+              <path d="M19.2405 16.1852L18.5436 14.3733C18.4571 14.1484 18.241 14 18 14C17.759 14 17.5429 14.1484 17.4564 14.3733L16.7595 16.1852C16.658 16.4493 16.4493 16.658 16.1852 16.7595L14.3733 17.4564C14.1484 17.5429 14 17.759 14 18C14 18.241 14.1484 18.4571 14.3733 18.5436L16.1852 19.2405C16.4493 19.342 16.658 19.5507 16.7595 19.8148L17.4564 21.6267C17.5429 21.8516 17.759 22 18 22C18.241 22 18.4571 21.8516 18.5436 21.6267L19.2405 19.8148C19.342 19.5507 19.5507 19.342 19.8148 19.2405L21.6267 18.5436C21.8516 18.4571 22 18.241 22 18C22 17.759 21.8516 17.5429 21.6267 17.4564L19.8148 16.7595C19.5507 16.658 19.342 16.4493 19.2405 16.1852Z" fill="currentColor" />
+              <path d="M16 5H17C18.6569 5 20 6.34315 20 8V11M8 5H7C5.34315 5 4 6.34315 4 8V18C4 19.6569 5.34315 21 7 21H12" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </span>
+          <span
+            ref={copyCheckIconRef}
+            class="dialkit-toolbar-copy-icon"
+            style={{ opacity: 0, transform: 'scale(0.5)', filter: 'blur(4px)' }}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16">
+              <path d="M5 12.75L10 19L19 5" />
+            </svg>
+          </span>
+        </span>
+        Copy
+      </button>
+    </>
+  );
+
+  return (
+    <div class="dialkit-panel-wrapper">
+      <Folder title={props.panel.name} defaultOpen={true} isRoot={true} onOpenChange={setIsPanelOpen} toolbar={toolbar}>
+        {renderControls()}
+      </Folder>
+    </div>
+  );
+}

--- a/src/solid/components/PresetManager.tsx
+++ b/src/solid/components/PresetManager.tsx
@@ -1,0 +1,199 @@
+import { createSignal, createEffect, onMount, onCleanup, Show, For } from 'solid-js';
+import { Portal } from 'solid-js/web';
+import { animate } from 'motion';
+import { DialStore } from '../../store/DialStore';
+import type { Preset } from '../../store/DialStore';
+
+interface PresetManagerProps {
+  panelId: string;
+  presets: Preset[];
+  activePresetId: string | null;
+  onAdd: () => void;
+}
+
+export function PresetManager(props: PresetManagerProps) {
+  const [isOpen, setIsOpen] = createSignal(false);
+  const [mounted, setMounted] = createSignal(false);
+  const [pos, setPos] = createSignal({ top: 0, left: 0, width: 0 });
+  const [portalTarget, setPortalTarget] = createSignal<HTMLElement | null>(null);
+  let triggerRef!: HTMLButtonElement;
+  let dropdownRef: HTMLDivElement | undefined;
+  let chevronRef!: SVGSVGElement;
+  let closeAnim: any = null;
+  let chevronAnim: any = null;
+
+  const hasPresets = () => props.presets.length > 0;
+  const activePreset = () => props.presets.find((p) => p.id === props.activePresetId);
+
+  onMount(() => {
+    const root = triggerRef?.closest('.dialkit-root') as HTMLElement | null;
+    setPortalTarget(root ?? document.body);
+
+    if (chevronRef) {
+      chevronRef.style.transform = `rotate(${isOpen() ? 180 : 0}deg)`;
+      chevronRef.style.opacity = String(hasPresets() ? 0.6 : 0.25);
+    }
+
+    onCleanup(() => {
+      closeAnim?.stop();
+      chevronAnim?.stop();
+    });
+  });
+
+  createEffect(() => {
+    if (!chevronRef) return;
+    const open = isOpen();
+    const has = hasPresets();
+    chevronAnim?.stop();
+    chevronAnim = animate(
+      chevronRef,
+      { rotate: open ? 180 : 0, opacity: has ? 0.6 : 0.25 },
+      { type: 'spring', visualDuration: 0.2, bounce: 0.15 }
+    );
+  });
+
+  const updatePos = () => {
+    const rect = triggerRef?.getBoundingClientRect();
+    if (!rect) return;
+    setPos({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+  };
+
+  const openDropdown = () => {
+    if (!hasPresets()) return;
+    updatePos();
+    closeAnim?.stop();
+    closeAnim = null;
+    setMounted(true);
+    setIsOpen(true);
+  };
+
+  const closeDropdown = () => {
+    setIsOpen(false);
+    if (!dropdownRef) { setMounted(false); return; }
+    closeAnim?.stop();
+    closeAnim = animate(
+      dropdownRef,
+      { opacity: 0, y: 4, scale: 0.97 },
+      { type: 'spring', visualDuration: 0.15, bounce: 0, onComplete: () => { setMounted(false); closeAnim = null; } }
+    );
+  };
+
+  const toggle = () => { if (isOpen()) closeDropdown(); else openDropdown(); };
+
+  // Close on click outside
+  createEffect(() => {
+    if (!isOpen()) return;
+    const handleViewportChange = () => updatePos();
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (triggerRef?.contains(target) || dropdownRef?.contains(target)) return;
+      closeDropdown();
+    };
+    updatePos();
+    document.addEventListener('mousedown', handler);
+    window.addEventListener('resize', handleViewportChange);
+    window.addEventListener('scroll', handleViewportChange, true);
+    onCleanup(() => {
+      document.removeEventListener('mousedown', handler);
+      window.removeEventListener('resize', handleViewportChange);
+      window.removeEventListener('scroll', handleViewportChange, true);
+    });
+  });
+
+  const handleSelect = (presetId: string | null) => {
+    if (presetId) DialStore.loadPreset(props.panelId, presetId);
+    else DialStore.clearActivePreset(props.panelId);
+    closeDropdown();
+  };
+
+  const handleDelete = (e: MouseEvent, presetId: string) => {
+    e.stopPropagation();
+    DialStore.deletePreset(props.panelId, presetId);
+  };
+
+  return (
+    <div class="dialkit-preset-manager">
+      <button
+        ref={triggerRef}
+        class="dialkit-preset-trigger"
+        onClick={toggle}
+        data-open={String(isOpen())}
+        data-has-preset={String(!!activePreset())}
+        data-disabled={String(!hasPresets())}
+      >
+        <span class="dialkit-preset-label">
+          {activePreset() ? activePreset()!.name : 'Version 1'}
+        </span>
+        <svg
+          ref={chevronRef}
+          class="dialkit-select-chevron"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2.5"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M6 9.5L12 15.5L18 9.5" />
+        </svg>
+      </button>
+
+      <Show when={!!portalTarget()}>
+        <Portal mount={portalTarget()!}>
+          <Show when={mounted()}>
+            <div
+              ref={(el) => {
+                dropdownRef = el;
+                animate(
+                  el,
+                  { opacity: [0, 1], y: [4, 0], scale: [0.97, 1] },
+                  { type: 'spring', visualDuration: 0.15, bounce: 0 }
+                );
+              }}
+              class="dialkit-root dialkit-preset-dropdown"
+              style={{
+                position: 'fixed',
+                top: `${pos().top}px`,
+                left: `${pos().left}px`,
+                'min-width': `${pos().width}px`,
+              }}
+            >
+              <div
+                class="dialkit-preset-item"
+                data-active={String(!props.activePresetId)}
+                onClick={() => handleSelect(null)}
+              >
+                <span class="dialkit-preset-name">Version 1</span>
+              </div>
+
+              <For each={props.presets}>
+                {(preset) => (
+                  <div
+                    class="dialkit-preset-item"
+                    data-active={String(preset.id === props.activePresetId)}
+                    onClick={() => handleSelect(preset.id)}
+                  >
+                    <span class="dialkit-preset-name">{preset.name}</span>
+                    <button
+                      class="dialkit-preset-delete"
+                      onClick={(e) => handleDelete(e, preset.id)}
+                      title="Delete preset"
+                    >
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M5 6.5L5.80734 18.2064C5.91582 19.7794 7.22348 21 8.80023 21H15.1998C16.7765 21 18.0842 19.7794 18.1927 18.2064L19 6.5" />
+                        <path d="M10 11V16" />
+                        <path d="M14 11V16" />
+                        <path d="M3.5 6H20.5" />
+                        <path d="M8.07092 5.74621C8.42348 3.89745 10.0485 2.5 12 2.5C13.9515 2.5 15.5765 3.89745 15.9291 5.74621" />
+                      </svg>
+                    </button>
+                  </div>
+                )}
+              </For>
+            </div>
+          </Show>
+        </Portal>
+      </Show>
+    </div>
+  );
+}

--- a/src/solid/components/SegmentedControl.tsx
+++ b/src/solid/components/SegmentedControl.tsx
@@ -1,0 +1,118 @@
+import { createSignal, createRenderEffect, onMount, onCleanup, For } from 'solid-js';
+import { animate } from 'motion';
+
+interface SegmentedControlOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface SegmentedControlProps<T extends string> {
+  options: [SegmentedControlOption<T>, SegmentedControlOption<T>];
+  value: T;
+  onChange: (value: T) => void;
+}
+
+export function SegmentedControl<T extends string>(props: SegmentedControlProps<T>) {
+  let containerRef!: HTMLDivElement;
+  let pillRef!: HTMLDivElement;
+  const buttonRefs = new Map<T, HTMLButtonElement>();
+  const [pillReady, setPillReady] = createSignal(false);
+
+  let hasAnimated = false;
+  let pillAnim: any = null;
+
+  const measurePill = () => {
+    const button = buttonRefs.get(props.value);
+    if (!button || !containerRef) return null;
+    const containerRect = containerRef.getBoundingClientRect();
+    const buttonRect = button.getBoundingClientRect();
+    return {
+      left: buttonRect.left - containerRect.left,
+      width: buttonRect.width,
+    };
+  };
+
+  const setPillImmediate = (left: number, width: number) => {
+    if (!pillRef) return;
+    pillRef.style.left = `${left}px`;
+    pillRef.style.width = `${width}px`;
+  };
+
+  const updatePill = (shouldAnimate: boolean) => {
+    const next = measurePill();
+    if (!next) return;
+
+    if (!pillReady()) {
+      setPillImmediate(next.left, next.width);
+      setPillReady(true);
+      return;
+    }
+
+    if (!shouldAnimate || !hasAnimated) {
+      pillAnim?.stop();
+      pillAnim = null;
+      setPillImmediate(next.left, next.width);
+      return;
+    }
+
+    pillAnim?.stop();
+    pillAnim = animate(pillRef, {
+      left: next.left,
+      width: next.width,
+    }, {
+      type: 'spring',
+      visualDuration: 0.2,
+      bounce: 0.15,
+      onComplete: () => {
+        pillAnim = null;
+      },
+    });
+  };
+
+  createRenderEffect(() => {
+    const _ = props.value;
+    if (!pillReady()) return;
+    updatePill(true);
+  });
+
+  onMount(() => {
+    requestAnimationFrame(() => {
+      updatePill(false);
+      hasAnimated = true;
+    });
+
+    if (typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => updatePill(false));
+    ro.observe(containerRef);
+
+    onCleanup(() => {
+      pillAnim?.stop();
+      ro.disconnect();
+    });
+  });
+
+  return (
+    <div ref={containerRef} class="dialkit-segmented">
+      <div
+        ref={pillRef}
+        class="dialkit-segmented-pill"
+        style={{ left: '0px', width: '0px', visibility: pillReady() ? 'visible' : 'hidden' }}
+      />
+      <For each={props.options}>
+        {(option) => (
+          <button
+            ref={(el) => {
+              if (!el) return;
+              buttonRefs.set(option.value, el);
+            }}
+            onClick={() => props.onChange(option.value)}
+            class="dialkit-segmented-button"
+            data-active={String(props.value === option.value)}
+          >
+            {option.label}
+          </button>
+        )}
+      </For>
+    </div>
+  );
+}

--- a/src/solid/components/SelectControl.tsx
+++ b/src/solid/components/SelectControl.tsx
@@ -1,0 +1,198 @@
+import { createSignal, createEffect, onMount, onCleanup, Show, For } from 'solid-js';
+import { Portal } from 'solid-js/web';
+import { animate } from 'motion';
+
+type SelectOption = string | { value: string; label: string };
+
+interface SelectControlProps {
+  label: string;
+  value: string;
+  options: SelectOption[];
+  onChange: (value: string) => void;
+}
+
+function toTitleCase(s: string): string {
+  return s.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function normalizeOptions(options: SelectOption[]): { value: string; label: string }[] {
+  return options.map((opt) =>
+    typeof opt === 'string' ? { value: opt, label: toTitleCase(opt) } : opt
+  );
+}
+
+export function SelectControl(props: SelectControlProps) {
+  const [isOpen, setIsOpen] = createSignal(false);
+  const [mounted, setMounted] = createSignal(false);
+  const [pos, setPos] = createSignal<{ top: number; left: number; width: number; above: boolean } | null>(null);
+  const [portalTarget, setPortalTarget] = createSignal<HTMLElement | null>(null);
+  let triggerRef!: HTMLButtonElement;
+  let dropdownRef: HTMLDivElement | undefined;
+  let chevronRef!: SVGSVGElement;
+  let closeAnim: any = null;
+  let chevronAnim: any = null;
+
+  const normalized = () => normalizeOptions(props.options);
+  const selectedOption = () => normalized().find((o) => o.value === props.value);
+
+  onMount(() => {
+    const root = triggerRef?.closest('.dialkit-root') as HTMLElement | null;
+    setPortalTarget(root ?? document.body);
+
+    if (chevronRef) {
+      chevronRef.style.transform = `rotate(${isOpen() ? 180 : 0}deg)`;
+    }
+
+    onCleanup(() => {
+      closeAnim?.stop();
+      chevronAnim?.stop();
+    });
+  });
+
+  createEffect(() => {
+    if (!chevronRef) return;
+    const open = isOpen();
+    chevronAnim?.stop();
+    chevronAnim = animate(
+      chevronRef,
+      { rotate: open ? 180 : 0 },
+      { type: 'spring', visualDuration: 0.2, bounce: 0.15 }
+    );
+  });
+
+  const updatePos = () => {
+    if (!triggerRef) return;
+    const rect = triggerRef.getBoundingClientRect();
+    const dropdownHeight = 8 + normalized().length * 36;
+    const spaceBelow = window.innerHeight - rect.bottom - 4;
+    const above = spaceBelow < dropdownHeight && rect.top > spaceBelow;
+    setPos({
+      top: above ? rect.top - 4 : rect.bottom + 4,
+      left: rect.left,
+      width: rect.width,
+      above,
+    });
+  };
+
+  const openDropdown = () => {
+    closeAnim?.stop();
+    closeAnim = null;
+    updatePos();
+    setMounted(true);
+    setIsOpen(true);
+  };
+
+  const closeDropdown = () => {
+    setIsOpen(false);
+    if (!dropdownRef) { setMounted(false); return; }
+    const above = pos()?.above ?? false;
+    closeAnim?.stop();
+    closeAnim = animate(
+      dropdownRef,
+      { opacity: 0, y: above ? 8 : -8, scale: 0.95 },
+      { type: 'spring', visualDuration: 0.15, bounce: 0, onComplete: () => { setMounted(false); closeAnim = null; } }
+    );
+  };
+
+  // Close on click outside
+  createEffect(() => {
+    if (!isOpen()) return;
+    const handleViewportChange = () => updatePos();
+
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        triggerRef && !triggerRef.contains(target) &&
+        dropdownRef && !dropdownRef.contains(target)
+      ) {
+        closeDropdown();
+      }
+    };
+
+    updatePos();
+    document.addEventListener('mousedown', handleClick);
+    window.addEventListener('resize', handleViewportChange);
+    window.addEventListener('scroll', handleViewportChange, true);
+    onCleanup(() => {
+      document.removeEventListener('mousedown', handleClick);
+      window.removeEventListener('resize', handleViewportChange);
+      window.removeEventListener('scroll', handleViewportChange, true);
+    });
+  });
+
+  const dropdownStyle = () => {
+    const p = pos();
+    if (!p) return {};
+    return {
+      position: 'fixed' as const,
+      left: `${p.left}px`,
+      width: `${p.width}px`,
+      ...(p.above
+        ? { bottom: `${window.innerHeight - p.top}px`, 'transform-origin': 'bottom' }
+        : { top: `${p.top}px`, 'transform-origin': 'top' }),
+    };
+  };
+
+  return (
+    <div class="dialkit-select-row">
+      <button
+        ref={triggerRef}
+        class="dialkit-select-trigger"
+        onClick={() => isOpen() ? closeDropdown() : openDropdown()}
+        data-open={String(isOpen())}
+      >
+        <span class="dialkit-select-label">{props.label}</span>
+        <div class="dialkit-select-right">
+          <span class="dialkit-select-value">{selectedOption()?.label ?? props.value}</span>
+          <svg
+            ref={chevronRef}
+            class="dialkit-select-chevron"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M6 9.5L12 15.5L18 9.5" />
+          </svg>
+        </div>
+      </button>
+
+      <Show when={!!portalTarget()}>
+        <Portal mount={portalTarget()!}>
+          <Show when={mounted() && pos()}>
+            <div
+              ref={(el) => {
+                dropdownRef = el;
+                const above = pos()?.above ?? false;
+                animate(
+                  el,
+                  { opacity: [0, 1], y: [above ? 8 : -8, 0], scale: [0.95, 1] },
+                  { type: 'spring', visualDuration: 0.15, bounce: 0 }
+                );
+              }}
+              class="dialkit-select-dropdown"
+              style={dropdownStyle()}
+            >
+              <For each={normalized()}>
+                {(option) => (
+                  <button
+                    class="dialkit-select-option"
+                    data-selected={String(option.value === props.value)}
+                    onClick={() => {
+                      props.onChange(option.value);
+                      closeDropdown();
+                    }}
+                  >
+                    {option.label}
+                  </button>
+                )}
+              </For>
+            </div>
+          </Show>
+        </Portal>
+      </Show>
+    </div>
+  );
+}

--- a/src/solid/components/Slider.tsx
+++ b/src/solid/components/Slider.tsx
@@ -1,0 +1,444 @@
+import { createSignal, createEffect, onMount, onCleanup } from 'solid-js';
+import { animate, motionValue } from 'motion';
+
+interface SliderProps {
+  label: string;
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  unit?: string;
+}
+
+const CLICK_THRESHOLD = 3;
+const DEAD_ZONE = 32;
+const MAX_CURSOR_RANGE = 200;
+const MAX_STRETCH = 8;
+
+function decimalsForStep(step: number): number {
+  const s = step.toString();
+  const dot = s.indexOf('.');
+  return dot === -1 ? 0 : s.length - dot - 1;
+}
+
+function roundValue(val: number, step: number): number {
+  const raw = Math.round(val / step) * step;
+  return parseFloat(raw.toFixed(decimalsForStep(step)));
+}
+
+function snapToDecile(rawValue: number, min: number, max: number): number {
+  const normalized = (rawValue - min) / (max - min);
+  const nearest = Math.round(normalized * 10) / 10;
+  if (Math.abs(normalized - nearest) <= 0.03125) {
+    return min + nearest * (max - min);
+  }
+  return rawValue;
+}
+
+export function Slider(props: SliderProps) {
+  const min = () => props.min ?? 0;
+  const max = () => props.max ?? 1;
+  const step = () => props.step ?? 0.01;
+
+  let wrapperRef!: HTMLDivElement;
+  let trackRef!: HTMLDivElement;
+  let fillRef!: HTMLDivElement;
+  let handleRef!: HTMLDivElement;
+  let labelRef!: HTMLSpanElement;
+  let valueSpanRef!: HTMLSpanElement;
+  let inputRef!: HTMLInputElement;
+
+  const [isInteracting, setIsInteracting] = createSignal(false);
+  const [isDragging, setIsDragging] = createSignal(false);
+  const [isHovered, setIsHovered] = createSignal(false);
+  const [isValueHovered, setIsValueHovered] = createSignal(false);
+  const [isValueEditable, setIsValueEditable] = createSignal(false);
+  const [showInput, setShowInput] = createSignal(false);
+  const [inputValue, setInputValue] = createSignal('');
+
+  const fillPercent = motionValue(((props.value - min()) / (max() - min())) * 100);
+  const rubberStretchPx = motionValue(0);
+  const handleOpacityMv = motionValue(0);
+  const handleScaleXMv = motionValue(0.25);
+  const handleScaleYMv = motionValue(1);
+
+  const applyFillStyles = (pct: number) => {
+    if (fillRef) fillRef.style.width = `${pct}%`;
+    if (handleRef) handleRef.style.left = `max(5px, calc(${pct}% - 9px))`;
+  };
+
+  const applyRubberStyles = (stretch: number) => {
+    if (!trackRef) return;
+    trackRef.style.width = `calc(100% + ${Math.abs(stretch)}px)`;
+    trackRef.style.transform = `translateX(${stretch < 0 ? stretch : 0}px)`;
+  };
+
+  const applyHandleVisualStyles = () => {
+    if (!handleRef) return;
+    handleRef.style.opacity = String(handleOpacityMv.get());
+    handleRef.style.transform = `translateY(-50%) scaleX(${handleScaleXMv.get()}) scaleY(${handleScaleYMv.get()})`;
+  };
+
+  // Sync fill from props when not interacting
+  createEffect(() => {
+    if (!isInteracting() && !snapAnim) {
+      fillPercent.jump(((props.value - min()) / (max() - min())) * 100);
+    }
+  });
+
+  const percentage = () => ((props.value - min()) / (max() - min())) * 100;
+  const isActive = () => isInteracting() || isHovered();
+
+  let pointerDownPos: { x: number; y: number } | null = null;
+  let isClickFlag = true;
+  let wrapperRect: DOMRect | null = null;
+  let scaleVal = 1;
+  let hoverTimeout: ReturnType<typeof setTimeout> | null = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let snapAnim: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let rubberAnim: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handleOpacityAnim: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handleScaleXAnim: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let handleScaleYAnim: any = null;
+
+  const positionToValue = (clientX: number) => {
+    if (!wrapperRect) return props.value;
+    const screenX = clientX - wrapperRect.left;
+    const sceneX = screenX / scaleVal;
+    const nativeWidth = wrapperRef ? wrapperRef.offsetWidth : wrapperRect.width;
+    const percent = Math.max(0, Math.min(1, sceneX / nativeWidth));
+    const rawValue = min() + percent * (max() - min());
+    return Math.max(min(), Math.min(max(), rawValue));
+  };
+
+  const percentFromValue = (v: number) => ((v - min()) / (max() - min())) * 100;
+
+  const computeRubberStretch = (clientX: number, sign: number) => {
+    if (!wrapperRect) return 0;
+    const distancePast = sign < 0 ? wrapperRect.left - clientX : clientX - wrapperRect.right;
+    const overflow = Math.max(0, distancePast - DEAD_ZONE);
+    return sign * MAX_STRETCH * Math.sqrt(Math.min(overflow / MAX_CURSOR_RANGE, 1.0));
+  };
+
+  const cancelInteraction = () => {
+    if (!isInteracting()) return;
+    setIsInteracting(false);
+    setIsDragging(false);
+    rubberStretchPx.jump(0);
+    pointerDownPos = null;
+  };
+
+  const handlePointerDown = (e: PointerEvent) => {
+    if (showInput()) return;
+    e.preventDefault();
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    pointerDownPos = { x: e.clientX, y: e.clientY };
+    isClickFlag = true;
+    setIsInteracting(true);
+
+    if (wrapperRef) {
+      wrapperRect = wrapperRef.getBoundingClientRect();
+      scaleVal = wrapperRect.width / wrapperRef.offsetWidth;
+    }
+  };
+
+  const handlePointerMove = (e: PointerEvent) => {
+    if (!isInteracting() || !pointerDownPos) return;
+
+    const dx = e.clientX - pointerDownPos.x;
+    const dy = e.clientY - pointerDownPos.y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+
+    if (isClickFlag && distance > CLICK_THRESHOLD) {
+      isClickFlag = false;
+      setIsDragging(true);
+    }
+
+    if (!isClickFlag) {
+      if (wrapperRect) {
+        if (e.clientX < wrapperRect.left) {
+          rubberStretchPx.jump(computeRubberStretch(e.clientX, -1));
+        } else if (e.clientX > wrapperRect.right) {
+          rubberStretchPx.jump(computeRubberStretch(e.clientX, 1));
+        } else {
+          rubberStretchPx.jump(0);
+        }
+      }
+
+      const newValue = positionToValue(e.clientX);
+      const newPct = percentFromValue(newValue);
+      if (snapAnim) { snapAnim.stop(); snapAnim = null; }
+      fillPercent.jump(newPct);
+      props.onChange(roundValue(newValue, step()));
+    }
+  };
+
+  const handlePointerUp = (e: PointerEvent) => {
+    if (!isInteracting()) return;
+
+    if (isClickFlag) {
+      const rawValue = positionToValue(e.clientX);
+      const discreteSteps = (max() - min()) / step();
+      const snappedValue = discreteSteps <= 10
+        ? Math.max(min(), Math.min(max(), min() + Math.round((rawValue - min()) / step()) * step()))
+        : snapToDecile(rawValue, min(), max());
+
+      const newPct = percentFromValue(snappedValue);
+
+      if (snapAnim) snapAnim.stop();
+      snapAnim = animate(fillPercent, newPct, {
+        type: 'spring',
+        stiffness: 300,
+        damping: 25,
+        mass: 0.8,
+        onComplete: () => {
+          snapAnim = null;
+        },
+      });
+
+      props.onChange(roundValue(snappedValue, step()));
+    }
+
+    if (rubberStretchPx.get() !== 0) {
+      if (rubberAnim) rubberAnim.stop();
+      rubberAnim = animate(rubberStretchPx, 0, {
+        type: 'spring',
+        visualDuration: 0.35,
+        bounce: 0.15,
+      });
+    }
+
+    setIsInteracting(false);
+    setIsDragging(false);
+    pointerDownPos = null;
+  };
+
+  const handlePointerCancel = () => {
+    cancelInteraction();
+  };
+
+  // Handle value hover delay — clear pending timer on each re-run
+  createEffect(() => {
+    const hovered = isValueHovered();
+    const editing = showInput();
+    const editable = isValueEditable();
+
+    onCleanup(() => {
+      if (hoverTimeout) { clearTimeout(hoverTimeout); hoverTimeout = null; }
+    });
+
+    if (hovered && !editing && !editable) {
+      hoverTimeout = setTimeout(() => setIsValueEditable(true), 800);
+    } else if (!hovered && !editing) {
+      setIsValueEditable(false);
+    }
+  });
+
+  onCleanup(() => {
+    if (hoverTimeout) clearTimeout(hoverTimeout);
+    snapAnim?.stop();
+    rubberAnim?.stop();
+    handleOpacityAnim?.stop();
+    handleScaleXAnim?.stop();
+    handleScaleYAnim?.stop();
+  });
+
+  onMount(() => {
+    const unsubFill = fillPercent.on('change', applyFillStyles);
+    const unsubRubber = rubberStretchPx.on('change', applyRubberStyles);
+    const unsubHandleOpacity = handleOpacityMv.on('change', applyHandleVisualStyles);
+    const unsubHandleScaleX = handleScaleXMv.on('change', applyHandleVisualStyles);
+    const unsubHandleScaleY = handleScaleYMv.on('change', applyHandleVisualStyles);
+    applyFillStyles(fillPercent.get());
+    applyRubberStyles(rubberStretchPx.get());
+    applyHandleVisualStyles();
+
+    onCleanup(() => {
+      unsubFill();
+      unsubRubber();
+      unsubHandleOpacity();
+      unsubHandleScaleX();
+      unsubHandleScaleY();
+    });
+  });
+
+  // Focus input when it appears
+  createEffect(() => {
+    if (showInput() && inputRef) {
+      inputRef.focus();
+      inputRef.select();
+    }
+  });
+
+  const handleInputSubmit = () => {
+    const parsed = parseFloat(inputValue());
+    if (!isNaN(parsed)) {
+      const clamped = Math.max(min(), Math.min(max(), parsed));
+      props.onChange(roundValue(clamped, step()));
+    }
+    setShowInput(false);
+    setIsValueHovered(false);
+    setIsValueEditable(false);
+  };
+
+  const handleValueClick = (e: MouseEvent) => {
+    if (isValueEditable()) {
+      e.stopPropagation();
+      e.preventDefault();
+      setShowInput(true);
+      setInputValue(props.value.toFixed(decimalsForStep(step())));
+    }
+  };
+
+  const handleInputKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') handleInputSubmit();
+    else if (e.key === 'Escape') {
+      setShowInput(false);
+      setIsValueHovered(false);
+    }
+  };
+
+  const displayValue = () => props.value.toFixed(decimalsForStep(step()));
+
+  // Value dodge: fade handle when it overlaps label or value text
+  const HANDLE_BUFFER = 8;
+  const LABEL_CSS_LEFT = 10;
+  const VALUE_CSS_RIGHT = 10;
+
+  const leftThreshold = () => {
+    const trackWidth = wrapperRef?.offsetWidth;
+    if (trackWidth && labelRef) {
+      return ((LABEL_CSS_LEFT + labelRef.offsetWidth + HANDLE_BUFFER) / trackWidth) * 100;
+    }
+    return 30;
+  };
+
+  const rightThreshold = () => {
+    const trackWidth = wrapperRef?.offsetWidth;
+    if (trackWidth && valueSpanRef) {
+      return ((trackWidth - VALUE_CSS_RIGHT - valueSpanRef.offsetWidth - HANDLE_BUFFER) / trackWidth) * 100;
+    }
+    return 78;
+  };
+
+  const valueDodge = () => percentage() < leftThreshold() || percentage() > rightThreshold();
+
+  const handleOpacity = () => {
+    if (!isActive()) return 0;
+    if (valueDodge()) return 0.1;
+    if (isDragging()) return 0.9;
+    return 0.5;
+  };
+
+  createEffect(() => {
+    const targetOpacity = handleOpacity();
+    const targetScaleX = isActive() ? 1 : 0.25;
+    const targetScaleY = isActive() && valueDodge() ? 0.75 : 1;
+
+    handleOpacityAnim?.stop();
+    handleScaleXAnim?.stop();
+    handleScaleYAnim?.stop();
+
+    handleOpacityAnim = animate(handleOpacityMv, targetOpacity, { duration: 0.15 });
+    handleScaleXAnim = animate(handleScaleXMv, targetScaleX, {
+      type: 'spring',
+      visualDuration: 0.25,
+      bounce: 0.15,
+    });
+    handleScaleYAnim = animate(handleScaleYMv, targetScaleY, {
+      type: 'spring',
+      visualDuration: 0.2,
+      bounce: 0.1,
+    });
+  });
+
+  const fillBackground = () =>
+    isActive() ? 'rgba(255, 255, 255, 0.15)' : 'rgba(255, 255, 255, 0.11)';
+
+  const discreteSteps = () => (max() - min()) / step();
+
+  const hashMarks = () => {
+    const ds = discreteSteps();
+    if (ds <= 10) {
+      return Array.from({ length: ds - 1 }, (_, i) => {
+        const pct = ((i + 1) * step()) / (max() - min()) * 100;
+        return <div class="dialkit-slider-hashmark" style={{ left: `${pct}%` }} />;
+      });
+    }
+    return Array.from({ length: 9 }, (_, i) => {
+      const pct = (i + 1) * 10;
+      return <div class="dialkit-slider-hashmark" style={{ left: `${pct}%` }} />;
+    });
+  };
+
+  return (
+    <div ref={wrapperRef} class="dialkit-slider-wrapper">
+      <div
+        ref={trackRef}
+        class={`dialkit-slider ${isActive() ? 'dialkit-slider-active' : ''}`}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <div class="dialkit-slider-hashmarks">{hashMarks()}</div>
+
+        <div
+          ref={fillRef}
+          class="dialkit-slider-fill"
+          style={{
+            background: fillBackground(),
+            width: `${fillPercent.get()}%`,
+            transition: 'background 0.15s',
+          }}
+        />
+
+        <div
+          ref={handleRef}
+          class="dialkit-slider-handle"
+          style={{
+            left: `max(5px, calc(${fillPercent.get()}% - 9px))`,
+            transform: 'translateY(-50%) scaleX(0.25) scaleY(1)',
+            opacity: 0,
+            background: 'rgba(255, 255, 255, 0.9)',
+          }}
+        />
+
+        <span ref={labelRef} class="dialkit-slider-label">{props.label}</span>
+
+        {showInput() ? (
+          <input
+            ref={inputRef}
+            type="text"
+            class="dialkit-slider-input"
+            value={inputValue()}
+            onInput={(e) => setInputValue(e.currentTarget.value)}
+            onKeyDown={handleInputKeyDown}
+            onBlur={handleInputSubmit}
+            onClick={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+          />
+        ) : (
+          <span
+            ref={valueSpanRef}
+            class={`dialkit-slider-value ${isValueEditable() ? 'dialkit-slider-value-editable' : ''}`}
+            onMouseEnter={() => setIsValueHovered(true)}
+            onMouseLeave={() => setIsValueHovered(false)}
+            onClick={handleValueClick}
+            onMouseDown={(e) => isValueEditable() && e.stopPropagation()}
+            style={{ cursor: isValueEditable() ? 'text' : 'default' }}
+          >
+            {displayValue()}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/solid/components/SpringControl.tsx
+++ b/src/solid/components/SpringControl.tsx
@@ -1,0 +1,133 @@
+import { createSignal, onMount, onCleanup } from 'solid-js';
+import { DialStore } from '../../store/DialStore';
+import type { SpringConfig } from '../../store/DialStore';
+import { Folder } from './Folder';
+import { Slider } from './Slider';
+import { SegmentedControl } from './SegmentedControl';
+import { SpringVisualization } from './SpringVisualization';
+
+interface SpringControlProps {
+  panelId: string;
+  path: string;
+  label: string;
+  spring: SpringConfig;
+  onChange: (spring: SpringConfig) => void;
+}
+
+export function SpringControl(props: SpringControlProps) {
+  const [mode, setMode] = createSignal<'simple' | 'advanced'>(
+    DialStore.getSpringMode(props.panelId, props.path)
+  );
+
+  // Subscribe to store changes for mode
+  onMount(() => {
+    const unsub = DialStore.subscribe(props.panelId, () => {
+      setMode(DialStore.getSpringMode(props.panelId, props.path));
+    });
+    onCleanup(unsub);
+  });
+
+  const isSimpleMode = () => mode() === 'simple';
+
+  const handleModeChange = (newMode: 'simple' | 'advanced') => {
+    DialStore.updateSpringMode(props.panelId, props.path, newMode);
+
+    if (newMode === 'simple') {
+      const { stiffness, damping, mass, ...rest } = props.spring;
+      props.onChange({
+        ...rest,
+        type: 'spring',
+        visualDuration: props.spring.visualDuration ?? 0.3,
+        bounce: props.spring.bounce ?? 0.2,
+      });
+    } else {
+      const { visualDuration, bounce, ...rest } = props.spring;
+      props.onChange({
+        ...rest,
+        type: 'spring',
+        stiffness: props.spring.stiffness ?? 200,
+        damping: props.spring.damping ?? 25,
+        mass: props.spring.mass ?? 1,
+      });
+    }
+  };
+
+  const handleUpdate = (key: keyof SpringConfig, value: number) => {
+    if (isSimpleMode()) {
+      const { stiffness, damping, mass, ...rest } = props.spring;
+      props.onChange({ ...rest, [key]: value });
+    } else {
+      const { visualDuration, bounce, ...rest } = props.spring;
+      props.onChange({ ...rest, [key]: value });
+    }
+  };
+
+  return (
+    <Folder title={props.label} defaultOpen={true}>
+      <div style={{ display: 'flex', 'flex-direction': 'column', gap: '6px' }}>
+        <SpringVisualization spring={props.spring} isSimpleMode={isSimpleMode()} />
+
+        <div class="dialkit-labeled-control">
+          <span class="dialkit-labeled-control-label">Type</span>
+          <SegmentedControl
+            options={[
+              { value: 'simple' as const, label: 'Time' },
+              { value: 'advanced' as const, label: 'Physics' },
+            ]}
+            value={mode()}
+            onChange={handleModeChange}
+          />
+        </div>
+
+        {isSimpleMode() ? (
+          <>
+            <Slider
+              label="Duration"
+              value={props.spring.visualDuration ?? 0.3}
+              onChange={(v) => handleUpdate('visualDuration', v)}
+              min={0.1}
+              max={1}
+              step={0.05}
+              unit="s"
+            />
+            <Slider
+              label="Bounce"
+              value={props.spring.bounce ?? 0.2}
+              onChange={(v) => handleUpdate('bounce', v)}
+              min={0}
+              max={1}
+              step={0.05}
+            />
+          </>
+        ) : (
+          <>
+            <Slider
+              label="Stiffness"
+              value={props.spring.stiffness ?? 400}
+              onChange={(v) => handleUpdate('stiffness', v)}
+              min={1}
+              max={1000}
+              step={10}
+            />
+            <Slider
+              label="Damping"
+              value={props.spring.damping ?? 17}
+              onChange={(v) => handleUpdate('damping', v)}
+              min={1}
+              max={100}
+              step={1}
+            />
+            <Slider
+              label="Mass"
+              value={props.spring.mass ?? 1}
+              onChange={(v) => handleUpdate('mass', v)}
+              min={0.1}
+              max={10}
+              step={0.1}
+            />
+          </>
+        )}
+      </div>
+    </Folder>
+  );
+}

--- a/src/solid/components/SpringVisualization.tsx
+++ b/src/solid/components/SpringVisualization.tsx
@@ -1,0 +1,113 @@
+import type { SpringConfig } from '../../store/DialStore';
+
+interface SpringVisualizationProps {
+  spring: SpringConfig;
+  isSimpleMode: boolean;
+}
+
+function generateSpringCurve(
+  stiffness: number,
+  damping: number,
+  mass: number,
+  duration: number
+): [number, number][] {
+  const points: [number, number][] = [];
+  const steps = 100;
+  const dt = duration / steps;
+
+  let position = 0;
+  let velocity = 0;
+  const target = 1;
+
+  for (let i = 0; i <= steps; i++) {
+    const time = i * dt;
+    points.push([time, position]);
+
+    const springForce = -stiffness * (position - target);
+    const dampingForce = -damping * velocity;
+    const acceleration = (springForce + dampingForce) / mass;
+
+    velocity += acceleration * dt;
+    position += velocity * dt;
+  }
+
+  return points;
+}
+
+export function SpringVisualization(props: SpringVisualizationProps) {
+  const width = 256;
+  const height = 140;
+
+  const params = () => {
+    let stiffness: number;
+    let damping: number;
+    let mass: number;
+
+    if (props.isSimpleMode) {
+      const visualDuration = props.spring.visualDuration ?? 0.3;
+      const bounce = props.spring.bounce ?? 0.2;
+      mass = 1;
+      stiffness = Math.pow((2 * Math.PI) / visualDuration, 2);
+      const dampingRatio = 1 - bounce;
+      damping = 2 * dampingRatio * Math.sqrt(stiffness * mass);
+    } else {
+      stiffness = props.spring.stiffness ?? 400;
+      damping = props.spring.damping ?? 17;
+      mass = props.spring.mass ?? 1;
+    }
+
+    const duration = 2;
+    const points = generateSpringCurve(stiffness, damping, mass, duration);
+    const values = points.map(([, value]) => value);
+    const minValue = Math.min(...values);
+    const maxValue = Math.max(...values);
+    const valueRange = maxValue - minValue;
+
+    const pathData = points
+      .map(([time, value], i) => {
+        const x = (time / duration) * width;
+        const normalizedValue = (value - minValue) / (valueRange || 1);
+        const y = height - (normalizedValue * height * 0.6 + height * 0.2);
+        return `${i === 0 ? 'M' : 'L'} ${x} ${y}`;
+      })
+      .join(' ');
+
+    return pathData;
+  };
+
+  const gridLines = () => {
+    const lines = [];
+    for (let i = 1; i < 4; i++) {
+      const x = (width / 4) * i;
+      const y = (height / 4) * i;
+      lines.push(
+        <line x1={x} y1={0} x2={x} y2={height} stroke="rgba(255, 255, 255, 0.08)" stroke-width="1" />,
+        <line x1={0} y1={y} x2={width} y2={y} stroke="rgba(255, 255, 255, 0.08)" stroke-width="1" />
+      );
+    }
+    return lines;
+  };
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} class="dialkit-spring-viz">
+      {gridLines()}
+      <line
+        x1={0}
+        y1={height / 2}
+        x2={width}
+        y2={height / 2}
+        stroke="rgba(255, 255, 255, 0.15)"
+        stroke-width="1"
+        stroke-dasharray="4,4"
+      />
+      <path
+        d={params()}
+        fill="none"
+        stroke="rgba(255, 255, 255, 0.6)"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/solid/components/TextControl.tsx
+++ b/src/solid/components/TextControl.tsx
@@ -1,0 +1,26 @@
+import { createUniqueId } from 'solid-js';
+
+interface TextControlProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export function TextControl(props: TextControlProps) {
+  const inputId = createUniqueId();
+
+  return (
+    <div class="dialkit-text-control">
+      <label class="dialkit-text-label" for={inputId}>{props.label}</label>
+      <input
+        id={inputId}
+        type="text"
+        class="dialkit-text-input"
+        value={props.value}
+        onInput={(e) => props.onChange(e.currentTarget.value)}
+        placeholder={props.placeholder}
+      />
+    </div>
+  );
+}

--- a/src/solid/components/Toggle.tsx
+++ b/src/solid/components/Toggle.tsx
@@ -1,0 +1,23 @@
+import { SegmentedControl } from './SegmentedControl';
+
+interface ToggleProps {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export function Toggle(props: ToggleProps) {
+  return (
+    <div class="dialkit-labeled-control">
+      <span class="dialkit-labeled-control-label">{props.label}</span>
+      <SegmentedControl
+        options={[
+          { value: 'off' as const, label: 'Off' },
+          { value: 'on' as const, label: 'On' },
+        ]}
+        value={props.checked ? 'on' : 'off'}
+        onChange={(val) => props.onChange(val === 'on')}
+      />
+    </div>
+  );
+}

--- a/src/solid/createDialKit.ts
+++ b/src/solid/createDialKit.ts
@@ -1,0 +1,104 @@
+import { createSignal, createMemo, onMount, onCleanup, createUniqueId, type Accessor } from 'solid-js';
+import { DialStore } from '../store/DialStore';
+import type { DialConfig, ResolvedValues, DialValue, SpringConfig, SelectConfig, ColorConfig, TextConfig, ActionConfig } from '../store/DialStore';
+
+export interface CreateDialOptions {
+  onAction?: (action: string) => void;
+}
+
+export function createDialKit<T extends DialConfig>(
+  name: string,
+  config: T,
+  options?: CreateDialOptions
+): Accessor<ResolvedValues<T>> {
+  const id = createUniqueId();
+  const panelId = `${name}-${id}`;
+
+  const [values, setValues] = createSignal<Record<string, DialValue>>(
+    DialStore.getValues(panelId)
+  );
+
+  onMount(() => {
+    DialStore.registerPanel(panelId, name, config);
+    setValues(DialStore.getValues(panelId));
+
+    const unsubValues = DialStore.subscribe(panelId, () => {
+      setValues(DialStore.getValues(panelId));
+    });
+
+    const unsubActions = options?.onAction
+      ? DialStore.subscribeActions(panelId, options.onAction)
+      : undefined;
+
+    onCleanup(() => {
+      unsubValues();
+      unsubActions?.();
+      DialStore.unregisterPanel(panelId);
+    });
+  });
+
+  return createMemo(() => buildResolvedValues(config, values(), '') as ResolvedValues<T>);
+}
+
+function buildResolvedValues(
+  config: DialConfig,
+  flatValues: Record<string, DialValue>,
+  prefix: string
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const [key, configValue] of Object.entries(config)) {
+    if (key === '_collapsed') continue;
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    if (Array.isArray(configValue) && configValue.length <= 4 && typeof configValue[0] === 'number') {
+      result[key] = flatValues[path] ?? configValue[0];
+    } else if (typeof configValue === 'number' || typeof configValue === 'boolean' || typeof configValue === 'string') {
+      result[key] = flatValues[path] ?? configValue;
+    } else if (isSpringConfig(configValue)) {
+      result[key] = flatValues[path] ?? configValue;
+    } else if (isActionConfig(configValue)) {
+      result[key] = flatValues[path] ?? configValue;
+    } else if (isSelectConfig(configValue)) {
+      const defaultValue = configValue.default ?? getFirstOptionValue(configValue.options);
+      result[key] = flatValues[path] ?? defaultValue;
+    } else if (isColorConfig(configValue)) {
+      result[key] = flatValues[path] ?? configValue.default ?? '#000000';
+    } else if (isTextConfig(configValue)) {
+      result[key] = flatValues[path] ?? configValue.default ?? '';
+    } else if (typeof configValue === 'object' && configValue !== null) {
+      result[key] = buildResolvedValues(configValue as DialConfig, flatValues, path);
+    }
+  }
+
+  return result;
+}
+
+function hasType(value: unknown, type: string): boolean {
+  return typeof value === 'object' && value !== null && 'type' in value && (value as { type: string }).type === type;
+}
+
+function isSpringConfig(value: unknown): value is SpringConfig {
+  return hasType(value, 'spring');
+}
+
+function isActionConfig(value: unknown): value is ActionConfig {
+  return hasType(value, 'action');
+}
+
+function isSelectConfig(value: unknown): value is SelectConfig {
+  return hasType(value, 'select') && 'options' in (value as object) && Array.isArray((value as SelectConfig).options);
+}
+
+function isColorConfig(value: unknown): value is ColorConfig {
+  return hasType(value, 'color');
+}
+
+function isTextConfig(value: unknown): value is TextConfig {
+  return hasType(value, 'text');
+}
+
+function getFirstOptionValue(options: (string | { value: string; label: string })[]): string {
+  const first = options[0];
+  return typeof first === 'string' ? first : first.value;
+}

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -1,0 +1,35 @@
+// Core API
+export { createDialKit } from './createDialKit';
+export type { CreateDialOptions } from './createDialKit';
+
+// Root component
+export { DialRoot } from './components/DialRoot';
+export type { DialPosition } from './components/DialRoot';
+
+// Component exports
+export { Slider } from './components/Slider';
+export { Toggle } from './components/Toggle';
+export { Folder } from './components/Folder';
+export { ButtonGroup } from './components/ButtonGroup';
+export { SpringControl } from './components/SpringControl';
+export { SpringVisualization } from './components/SpringVisualization';
+export { TextControl } from './components/TextControl';
+export { SelectControl } from './components/SelectControl';
+export { ColorControl } from './components/ColorControl';
+export { PresetManager } from './components/PresetManager';
+
+// Store exports
+export { DialStore } from '../store/DialStore';
+export type {
+  SpringConfig,
+  ActionConfig,
+  SelectConfig,
+  ColorConfig,
+  TextConfig,
+  Preset,
+  DialValue,
+  DialConfig,
+  ResolvedValues,
+  ControlMeta,
+  PanelConfig,
+} from '../store/DialStore';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,11 @@
     "resolveJsonModule": true,
     "isolatedModules": true
   },
-  "include": ["src/**/*"],
+  "include": [
+    "src/index.ts",
+    "src/components/**/*",
+    "src/hooks/**/*",
+    "src/store/**/*"
+  ],
   "exclude": ["node_modules", "dist", "example"]
 }

--- a/tsconfig.solid.json
+++ b/tsconfig.solid.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js"
+  },
+  "include": ["src/solid/**/*", "src/store/**/*"]
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,17 +1,38 @@
 import { defineConfig } from 'tsup';
+import { solidPlugin } from 'esbuild-plugin-solid';
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
-  dts: true,
-  splitting: false,
-  sourcemap: true,
-  clean: true,
-  external: ['react', 'react-dom', 'motion'],
-  esbuildOptions(options) {
-    options.banner = {
-      js: '"use client";',
-    };
+export default defineConfig([
+  // React build
+  {
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    dts: true,
+    splitting: false,
+    sourcemap: true,
+    clean: true,
+    external: ['react', 'react-dom', 'motion'],
+    esbuildOptions(options) {
+      options.banner = {
+        js: '"use client";',
+      };
+    },
+    onSuccess: 'cp src/styles/theme.css dist/styles.css',
   },
-  onSuccess: 'cp src/styles/theme.css dist/styles.css',
-});
+  // Solid build
+  {
+    entry: { index: 'src/solid/index.ts' },
+    outDir: 'dist/solid',
+    format: ['esm', 'cjs'],
+    dts: {
+      compilerOptions: {
+        jsx: 'preserve',
+        jsxImportSource: 'solid-js',
+      },
+    },
+    splitting: false,
+    sourcemap: true,
+    external: ['solid-js', 'solid-js/web', 'motion'],
+    tsconfig: 'tsconfig.solid.json',
+    esbuildPlugins: [solidPlugin()],
+  },
+]);


### PR DESCRIPTION
This solves at least 1 of the infinite set of integrations requested in https://github.com/joshpuckett/dialkit/issues/6 😅 

I have recorded a video explainer in tweet form, as I am wont to do.

https://x.com/kitlangton/status/2026450961384816673

## Summary
- Add a full Solid adapter (`dialkit/solid`) with `createDialKit`, `DialRoot`, and Solid implementations for all controls/components.
- Align Solid interaction/animation behavior with the React reference, including slider fill+handle sync, segmented/toggle initial state behavior, dropdown motion, and copy icon swap transitions.
- Update build and package config to emit Solid bundles/types, include Solid dependencies/peers, and remove unused dropdown keyframes from shared theme CSS.

## Validation
- `npm run build`
- `bun run typecheck`