### PR TITLE
Support nested action buttons and add contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to DialKit
+
+Thanks for contributing.
+
+## Development setup
+
+1. Fork and clone the repo.
+2. Install dependencies with `npm i`.
+3. Run `npm run typecheck` and `npm run build` before opening a PR.
+
+## Project notes
+
+- `src/styles/theme.css` is copied to `dist/styles.css` during build via `tsup` `onSuccess`.
+- `example/photostack` imports `dialkit/styles.css`, which resolves to `dist/styles.css`.
+- `ButtonGroup` actions should remain vertically stacked.
+
+## Pull request guidelines
+
+- Keep PRs single-responsibility and small.
+- Include a short summary of what changed and why.
+- Add validation notes (for example: `npm run typecheck`, `npm run build`).
+- Update `README.md` when behavior or API docs change.

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ const p = useDialKit('Controls', {
 ```
 
 Action buttons trigger callbacks without storing any value. The `label` defaults to the formatted key name (camelCase becomes Title Case). Multiple adjacent actions are grouped vertically.
+Action buttons can be placed at the root or nested inside folders.
 
 ### Folder
 

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -140,21 +140,8 @@ Apply these values as the new defaults in the useDialKit call.`;
           />
         );
 
-      default:
-        return null;
-    }
-  };
-
-  // Group consecutive actions together
-  const renderControls = () => {
-    const result: React.ReactNode[] = [];
-    let i = 0;
-
-    while (i < panel.controls.length) {
-      const control = panel.controls[i];
-
-      if (control.type === 'action') {
-        result.push(
+      case 'action':
+        return (
           <button
             key={control.path}
             className="dialkit-button"
@@ -163,14 +150,14 @@ Apply these values as the new defaults in the useDialKit call.`;
             {control.label}
           </button>
         );
-      } else {
-        result.push(renderControl(control));
-      }
 
-      i++;
+      default:
+        return null;
     }
+  };
 
-    return result;
+  const renderControls = () => {
+    return panel.controls.map(renderControl);
   };
 
   const iconTransition = { type: 'spring' as const, visualDuration: 0.4, bounce: 0.1 };


### PR DESCRIPTION
## Summary
- render action controls via the main control renderer so nested action buttons are displayed consistently
- document that action controls can be used at the root or inside folders
- add a CONTRIBUTING.md guide with setup, validation steps, and single-responsibility PR guidance

## Validation
- npm run typecheck
- npm run build
