### PR TITLE
Support dynamic config updates in useDialKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,18 @@ shadow: {
 
 DialKit also supports dynamic config updates. If your config shape, defaults, options, or labels change over time, the panel updates while preserving current values where paths still exist.
 
+For dynamic configs, memoize the config object so updates run only when dependencies actually change:
+
+```tsx
+import { useMemo } from 'react';
+
+const config = useMemo(() => ({
+  style: { type: 'select', options: dynamicOptions },
+}), [dynamicOptions]);
+
+const values = useDialKit('Controls', config);
+```
+
 ---
 
 ## DialRoot

--- a/src/hooks/useDialKit.ts
+++ b/src/hooks/useDialKit.ts
@@ -12,18 +12,26 @@ export function useDialKit<T extends DialConfig>(
 ): ResolvedValues<T> {
   const instanceId = useId();
   const panelId = `${name}-${instanceId}`;
+  const configRef = useRef(config);
+  const nameRef = useRef(name);
   const onActionRef = useRef(options?.onAction);
   onActionRef.current = options?.onAction;
 
   // Register panel on mount
   useEffect(() => {
-    DialStore.registerPanel(panelId, name, config);
+    DialStore.registerPanel(panelId, nameRef.current, configRef.current);
     return () => DialStore.unregisterPanel(panelId);
   }, [panelId]);
 
-  // Keep panel metadata and controls in sync with config/name changes.
+  // Update only when callers intentionally pass a new config reference (or rename panel).
   useEffect(() => {
+    if (configRef.current === config && nameRef.current === name) {
+      return;
+    }
+
     DialStore.updatePanel(panelId, name, config);
+    configRef.current = config;
+    nameRef.current = name;
   }, [panelId, name, config]);
 
   // Subscribe to action events


### PR DESCRIPTION
## Summary
- add `DialStore.updatePanel(...)` and call it from `useDialKit` when `name` or `config` changes
- preserve existing values (and spring mode state) for unchanged paths when config shape updates
- document dynamic config update behavior in README

## Validation
- npm run typecheck
- npm run build
