### PR TITLE
Add inline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,8 +256,21 @@ const values = useDialKit('Controls', {
 |------|------|---------|
 | `position` | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'` |
 | `defaultOpen` | `boolean` | `true` |
+| `mode` | `'popover' \| 'inline'` | `'popover'` |
 
-Mount once at your app root. The panel renders via a portal on `document.body`. It collapses to a small icon button and expands to 280px wide on click.
+Mount once at your app root. In the default `popover` mode, the panel renders via a portal on `document.body`. It collapses to a small icon button and expands to 280px wide on click.
+
+### Inline mode
+
+Use `mode="inline"` to render DialKit directly in your layout instead of as a floating popover. The panel fills its container and scrolls internally, which is useful for embedding in a sidebar or resizable panel:
+
+```tsx
+<aside style={{ width: 300, height: '100vh', overflow: 'hidden' }}>
+  <DialRoot mode="inline" />
+</aside>
+```
+
+In inline mode, the `position` prop is ignored and the collapse-to-icon behavior is disabled.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dialkit",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dialkit",
-      "version": "0.2.2",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.2.0",

--- a/src/components/DialRoot.tsx
+++ b/src/components/DialRoot.tsx
@@ -4,15 +4,18 @@ import { DialStore, PanelConfig } from '../store/DialStore';
 import { Panel } from './Panel';
 
 export type DialPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+export type DialMode = 'popover' | 'inline';
 
 interface DialRootProps {
   position?: DialPosition;
   defaultOpen?: boolean;
+  mode?: DialMode;
 }
 
-export function DialRoot({ position = 'top-right', defaultOpen = true }: DialRootProps) {
+export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'popover' }: DialRootProps) {
   const [panels, setPanels] = useState<PanelConfig[]>([]);
   const [mounted, setMounted] = useState(false);
+  const inline = mode === 'inline';
 
   // Subscribe to global panel changes
   useEffect(() => {
@@ -37,14 +40,18 @@ export function DialRoot({ position = 'top-right', defaultOpen = true }: DialRoo
   }
 
   const content = (
-    <div className="dialkit-root">
-      <div className="dialkit-panel" data-position={position}>
+    <div className="dialkit-root" data-mode={mode}>
+      <div className="dialkit-panel" data-position={inline ? undefined : position} data-mode={mode}>
         {panels.map((panel) => (
-          <Panel key={panel.id} panel={panel} defaultOpen={defaultOpen} />
+          <Panel key={panel.id} panel={panel} defaultOpen={inline || defaultOpen} inline={inline} />
         ))}
       </div>
     </div>
   );
+
+  if (inline) {
+    return content;
+  }
 
   return createPortal(content, document.body);
 }

--- a/src/components/Folder.tsx
+++ b/src/components/Folder.tsx
@@ -6,11 +6,12 @@ interface FolderProps {
   children: ReactNode;
   defaultOpen?: boolean;
   isRoot?: boolean;
+  inline?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   toolbar?: ReactNode;
 }
 
-export function Folder({ title, children, defaultOpen = true, isRoot = false, onOpenChange, toolbar }: FolderProps) {
+export function Folder({ title, children, defaultOpen = true, isRoot = false, inline = false, onOpenChange, toolbar }: FolderProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const [isCollapsed, setIsCollapsed] = useState(!defaultOpen);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -31,6 +32,7 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, on
   }, [isOpen]);
 
   const handleToggle = () => {
+    if (inline && isRoot) return;
     const next = !isOpen;
     setIsOpen(next);
     if (next) {
@@ -60,8 +62,7 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, on
               </span>
             </div>
           )}
-          {isRoot ? (
-            // Root panel icon — fixed position, container morphs around it
+          {isRoot && !inline && (
             <svg
               className="dialkit-panel-icon"
               viewBox="0 0 16 16"
@@ -72,8 +73,8 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, on
               <circle cx="10.4999" cy="3.5" r="0.998657" fill="currentColor" stroke="currentColor" strokeWidth="1.25"/>
               <circle cx="9.75015" cy="12.5" r="0.997986" fill="currentColor" stroke="currentColor" strokeWidth="1.25"/>
             </svg>
-          ) : (
-            // Section folders use rotating chevron with gentle spring
+          )}
+          {!isRoot && (
             <motion.svg
               className="dialkit-folder-icon"
               viewBox="0 0 24 24"
@@ -115,8 +116,15 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, on
     </div>
   );
 
-  // For root folders, wrap in panel container — instant open/close
   if (isRoot) {
+    if (inline) {
+      return (
+        <div className="dialkit-panel-inner dialkit-panel-inline">
+          {folderContent}
+        </div>
+      );
+    }
+
     const panelStyle = isOpen
       ? { width: 280, height: contentHeight !== undefined ? contentHeight + 24 : 'auto' as const, borderRadius: 14, boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)', cursor: undefined as string | undefined }
       : { width: 42, height: 42, borderRadius: 21, boxShadow: '0 4px 16px rgba(0, 0, 0, 0.25)', overflow: 'hidden' as const, cursor: 'pointer' as const };

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -14,9 +14,10 @@ import { PresetManager } from './PresetManager';
 interface PanelProps {
   panel: PanelConfig;
   defaultOpen?: boolean;
+  inline?: boolean;
 }
 
-export function Panel({ panel, defaultOpen = true }: PanelProps) {
+export function Panel({ panel, defaultOpen = true, inline = false }: PanelProps) {
   const [copied, setCopied] = useState(false);
   const [isPanelOpen, setIsPanelOpen] = useState(defaultOpen);
 
@@ -239,7 +240,7 @@ Apply these values as the new defaults in the useDialKit call.`;
 
   return (
     <div className="dialkit-panel-wrapper">
-      <Folder title={panel.name} defaultOpen={defaultOpen} isRoot={true} onOpenChange={setIsPanelOpen} toolbar={toolbar}>
+      <Folder title={panel.name} defaultOpen={defaultOpen} isRoot={true} inline={inline} onOpenChange={setIsPanelOpen} toolbar={toolbar}>
         {renderControls()}
       </Folder>
     </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export type { UseDialOptions } from './hooks/useDialKit';
 
 // Root component (user mounts once)
 export { DialRoot } from './components/DialRoot';
-export type { DialPosition } from './components/DialRoot';
+export type { DialPosition, DialMode } from './components/DialRoot';
 
 // Individual components (for advanced usage)
 export { Slider } from './components/Slider';

--- a/src/solid/components/DialRoot.tsx
+++ b/src/solid/components/DialRoot.tsx
@@ -5,15 +5,18 @@ import type { PanelConfig } from '../../store/DialStore';
 import { Panel } from './Panel';
 
 export type DialPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+export type DialMode = 'popover' | 'inline';
 
 interface DialRootProps {
   position?: DialPosition;
   defaultOpen?: boolean;
+  mode?: DialMode;
 }
 
 export function DialRoot(props: DialRootProps) {
   const [panels, setPanels] = createSignal<PanelConfig[]>([]);
   const [mounted, setMounted] = createSignal(false);
+  const inline = () => (props.mode ?? 'popover') === 'inline';
 
   onMount(() => {
     setMounted(true);
@@ -24,17 +27,23 @@ export function DialRoot(props: DialRootProps) {
     onCleanup(unsub);
   });
 
+  const content = () => (
+    <div class="dialkit-root" data-mode={props.mode ?? 'popover'}>
+      <div class="dialkit-panel" data-position={inline() ? undefined : (props.position ?? 'top-right')} data-mode={props.mode ?? 'popover'}>
+        <For each={panels()}>
+          {(panel) => <Panel panel={panel} defaultOpen={inline() || (props.defaultOpen ?? true)} inline={inline()} />}
+        </For>
+      </div>
+    </div>
+  );
+
   return (
     <Show when={mounted() && typeof window !== 'undefined' && panels().length > 0}>
-      <Portal mount={document.body}>
-        <div class="dialkit-root">
-          <div class="dialkit-panel" data-position={props.position ?? 'top-right'}>
-            <For each={panels()}>
-              {(panel) => <Panel panel={panel} defaultOpen={props.defaultOpen ?? true} />}
-            </For>
-          </div>
-        </div>
-      </Portal>
+      <Show when={!inline()} fallback={content()}>
+        <Portal mount={document.body}>
+          {content()}
+        </Portal>
+      </Show>
     </Show>
   );
 }

--- a/src/solid/components/Folder.tsx
+++ b/src/solid/components/Folder.tsx
@@ -6,6 +6,7 @@ interface FolderProps {
   children: JSX.Element;
   defaultOpen?: boolean;
   isRoot?: boolean;
+  inline?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   toolbar?: JSX.Element;
 }
@@ -61,6 +62,7 @@ export function Folder(props: FolderProps) {
   });
 
   const handleToggle = () => {
+    if (props.inline && props.isRoot) return;
     const next = !isOpen();
     setIsOpen(next);
     if (next) {
@@ -138,7 +140,7 @@ export function Folder(props: FolderProps) {
             </div>
           )}
 
-          {props.isRoot ? (
+          {props.isRoot && !props.inline && (
             <svg class="dialkit-panel-icon" viewBox="0 0 16 16" fill="none">
               <path
                 opacity="0.5"
@@ -149,7 +151,8 @@ export function Folder(props: FolderProps) {
               <circle cx="10.4999" cy="3.5" r="0.998657" fill="currentColor" stroke="currentColor" stroke-width="1.25" />
               <circle cx="9.75015" cy="12.5" r="0.997986" fill="currentColor" stroke="currentColor" stroke-width="1.25" />
             </svg>
-          ) : (
+          )}
+          {!props.isRoot && (
             <svg
               ref={folderChevronRef}
               class="dialkit-folder-icon"
@@ -204,8 +207,14 @@ export function Folder(props: FolderProps) {
     </div>
   );
 
-  // Root folders render inside the panel container.
   if (props.isRoot) {
+    if (props.inline) {
+      return (
+        <div class="dialkit-panel-inner dialkit-panel-inline">
+          {folderContent()}
+        </div>
+      );
+    }
     let panelRef!: HTMLDivElement;
     let rootPanelAnim: any = null;
     let rootPanelInitialized = false;

--- a/src/solid/components/Panel.tsx
+++ b/src/solid/components/Panel.tsx
@@ -14,6 +14,7 @@ import { PresetManager } from './PresetManager';
 interface PanelProps {
   panel: PanelConfig;
   defaultOpen?: boolean;
+  inline?: boolean;
 }
 
 export function Panel(props: PanelProps) {
@@ -295,7 +296,7 @@ export function Panel(props: PanelProps) {
 
   return (
     <div class="dialkit-panel-wrapper">
-      <Folder title={props.panel.name} defaultOpen={props.defaultOpen ?? true} isRoot={true} onOpenChange={setIsPanelOpen} toolbar={toolbar}>
+      <Folder title={props.panel.name} defaultOpen={props.defaultOpen ?? true} isRoot={true} inline={props.inline ?? false} onOpenChange={setIsPanelOpen} toolbar={toolbar}>
         {renderControls()}
       </Folder>
     </div>

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -4,7 +4,7 @@ export type { CreateDialOptions } from './createDialKit';
 
 // Root component
 export { DialRoot } from './components/DialRoot';
-export type { DialPosition } from './components/DialRoot';
+export type { DialPosition, DialMode } from './components/DialRoot';
 
 // Component exports
 export { Slider } from './components/Slider';

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -39,6 +39,19 @@
   overflow: visible;
 }
 
+/* Inline mode */
+.dialkit-root[data-mode="inline"] {
+  height: 100%;
+}
+
+.dialkit-panel[data-mode="inline"] {
+  position: static;
+  z-index: auto;
+  max-height: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 .dialkit-panel-inner {
   background: var(--dial-glass-bg);
   border: 1px solid var(--dial-border);
@@ -80,6 +93,24 @@
 .dialkit-panel-inner {
   -ms-overflow-style: none;
   scrollbar-width: none;
+}
+
+.dialkit-panel-inline {
+  width: 100%;
+  height: 100%;
+  max-height: none;
+  overflow-y: auto;
+  box-shadow: none;
+  border-radius: 0;
+  border: none;
+  box-sizing: border-box;
+}
+
+.dialkit-panel[data-mode="inline"] .dialkit-panel-wrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
 }
 
 /* Position variants */


### PR DESCRIPTION
## Summary
- Add `mode="inline"` prop to `DialRoot` (React + Solid) for rendering in-flow instead of as a fixed-position portal
- Skip collapse-to-icon behavior and portal when inline; panel fills its container and scrolls internally
- Document inline mode in README

## Validation
- `npm run build`