### PR TITLE
Fix: Segmented control pill misalignment on panel reopen

### DIFF
--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -1,5 +1,4 @@
-import { useRef, useState, useLayoutEffect } from 'react';
-import { motion } from 'motion/react';
+import { useRef } from 'react';
 
 interface SegmentedControlOption<T extends string> {
   value: T;
@@ -12,51 +11,42 @@ interface SegmentedControlProps<T extends string> {
   onChange: (value: T) => void;
 }
 
+const PADDING = 2;
+
 export function SegmentedControl<T extends string>({
   options,
   value,
   onChange,
 }: SegmentedControlProps<T>) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const buttonRefs = useRef<Map<T, HTMLButtonElement>>(new Map());
-  const [pillStyle, setPillStyle] = useState<{ left: number; width: number } | null>(null);
   const hasAnimated = useRef(false);
+  const activeIndex = options.findIndex((o) => o.value === value);
+  const count = options.length;
 
-  useLayoutEffect(() => {
-    const button = buttonRefs.current.get(value);
-    const container = containerRef.current;
-    if (button && container) {
-      const containerRect = container.getBoundingClientRect();
-      const buttonRect = button.getBoundingClientRect();
-      setPillStyle({
-        left: buttonRect.left - containerRect.left,
-        width: buttonRect.width,
-      });
-    }
-  }, [value]);
+  const pillLeft = `calc(${PADDING}px + ${activeIndex} * (100% - ${PADDING * 2}px) / ${count})`;
+  const pillWidth = `calc((100% - ${PADDING * 2}px) / ${count})`;
+
+  // Enable transition after first render
+  const shouldAnimate = hasAnimated.current;
+  hasAnimated.current = true;
 
   return (
-    <div ref={containerRef} className="dialkit-segmented">
-      {pillStyle && (
-        <motion.div
-          className="dialkit-segmented-pill"
-          style={{ left: pillStyle.left, width: pillStyle.width }}
-          animate={{ left: pillStyle.left, width: pillStyle.width }}
-          transition={
-            hasAnimated.current
-              ? { type: 'spring', visualDuration: 0.2, bounce: 0.15 }
-              : { duration: 0 }
-          }
-          onAnimationComplete={() => { hasAnimated.current = true; }}
-        />
-      )}
+    <div className="dialkit-segmented">
+      <div
+        className="dialkit-segmented-pill"
+        style={{
+          left: pillLeft,
+          width: pillWidth,
+          transition: shouldAnimate
+            ? 'left 0.2s cubic-bezier(0.25, 1, 0.5, 1), width 0.2s cubic-bezier(0.25, 1, 0.5, 1)'
+            : 'none',
+        }}
+      />
 
       {options.map((option) => {
         const isActive = value === option.value;
         return (
           <button
             key={option.value}
-            ref={(el) => { if (el) buttonRefs.current.set(option.value, el); }}
             onClick={() => onChange(option.value)}
             className="dialkit-segmented-button"
             data-active={String(isActive)}

--- a/src/solid/components/SegmentedControl.tsx
+++ b/src/solid/components/SegmentedControl.tsx
@@ -1,5 +1,4 @@
-import { createSignal, createRenderEffect, onMount, onCleanup, For } from 'solid-js';
-import { animate } from 'motion';
+import { For, createMemo } from 'solid-js';
 
 interface SegmentedControlOption<T extends string> {
   value: T;
@@ -12,99 +11,44 @@ interface SegmentedControlProps<T extends string> {
   onChange: (value: T) => void;
 }
 
+const PADDING = 2;
+
 export function SegmentedControl<T extends string>(props: SegmentedControlProps<T>) {
-  let containerRef!: HTMLDivElement;
-  let pillRef!: HTMLDivElement;
-  const buttonRefs = new Map<T, HTMLButtonElement>();
-  const [pillReady, setPillReady] = createSignal(false);
-
   let hasAnimated = false;
-  let pillAnim: any = null;
 
-  const measurePill = () => {
-    const button = buttonRefs.get(props.value);
-    if (!button || !containerRef) return null;
-    const containerRect = containerRef.getBoundingClientRect();
-    const buttonRect = button.getBoundingClientRect();
-    return {
-      left: buttonRect.left - containerRect.left,
-      width: buttonRect.width,
-    };
-  };
+  const activeIndex = createMemo(() =>
+    props.options.findIndex((o) => o.value === props.value)
+  );
 
-  const setPillImmediate = (left: number, width: number) => {
-    if (!pillRef) return;
-    pillRef.style.left = `${left}px`;
-    pillRef.style.width = `${width}px`;
-  };
+  const pillLeft = createMemo(() =>
+    `calc(${PADDING}px + ${activeIndex()} * (100% - ${PADDING * 2}px) / ${props.options.length})`
+  );
 
-  const updatePill = (shouldAnimate: boolean) => {
-    const next = measurePill();
-    if (!next) return;
+  const pillWidth = `calc((100% - ${PADDING * 2}px) / 2)`;
 
-    if (!pillReady()) {
-      setPillImmediate(next.left, next.width);
-      setPillReady(true);
-      return;
-    }
-
-    if (!shouldAnimate || !hasAnimated) {
-      pillAnim?.stop();
-      pillAnim = null;
-      setPillImmediate(next.left, next.width);
-      return;
-    }
-
-    pillAnim?.stop();
-    pillAnim = animate(pillRef, {
-      left: next.left,
-      width: next.width,
-    }, {
-      type: 'spring',
-      visualDuration: 0.2,
-      bounce: 0.15,
-      onComplete: () => {
-        pillAnim = null;
-      },
-    });
-  };
-
-  createRenderEffect(() => {
-    const _ = props.value;
-    if (!pillReady()) return;
-    updatePill(true);
-  });
-
-  onMount(() => {
-    requestAnimationFrame(() => {
-      updatePill(false);
+  const transition = createMemo(() => {
+    // Track value to re-evaluate on change
+    activeIndex();
+    if (!hasAnimated) {
       hasAnimated = true;
-    });
-
-    if (typeof ResizeObserver === 'undefined') return;
-    const ro = new ResizeObserver(() => updatePill(false));
-    ro.observe(containerRef);
-
-    onCleanup(() => {
-      pillAnim?.stop();
-      ro.disconnect();
-    });
+      return 'none';
+    }
+    return 'left 0.2s cubic-bezier(0.25, 1, 0.5, 1), width 0.2s cubic-bezier(0.25, 1, 0.5, 1)';
   });
 
   return (
-    <div ref={containerRef} class="dialkit-segmented">
+    <div class="dialkit-segmented">
       <div
-        ref={pillRef}
         class="dialkit-segmented-pill"
-        style={{ left: '0px', width: '0px', visibility: pillReady() ? 'visible' : 'hidden' }}
+        style={{
+          left: pillLeft(),
+          width: pillWidth,
+          transition: transition(),
+        }}
       />
       <For each={props.options}>
         {(option) => (
           <button
-            ref={(el) => {
-              if (!el) return;
-              buttonRefs.set(option.value, el);
-            }}
             onClick={() => props.onChange(option.value)}
             class="dialkit-segmented-button"
             data-active={String(props.value === option.value)}

--- a/src/svelte/components/SegmentedControl.svelte
+++ b/src/svelte/components/SegmentedControl.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { Spring } from 'svelte/motion';
-
   export interface SegmentedControlOption<T extends string = string> {
     value: T;
     label: string;
@@ -12,90 +10,36 @@
     onChange: (value: string) => void;
   }>();
 
-  let containerRef: HTMLDivElement | undefined;
-  const buttonRefs = new Map<string, HTMLButtonElement>();
-  let pillReady = $state(false);
+  const PADDING = 2;
+
   let hasAnimated = false;
 
-  const pillLeft = new Spring(0, { stiffness: 0.2, damping: 0.6 });
-  const pillWidth = new Spring(0, { stiffness: 0.2, damping: 0.6 });
-
-  const buttonRef = (node: HTMLButtonElement, key: string) => {
-    buttonRefs.set(key, node);
-    return {
-      destroy() {
-        buttonRefs.delete(key);
-      },
-    };
-  };
-
-  const measurePill = () => {
-    const button = buttonRefs.get(value);
-    if (!button || !containerRef) return null;
-    const containerRect = containerRef.getBoundingClientRect();
-    const buttonRect = button.getBoundingClientRect();
-
-    return {
-      left: buttonRect.left - containerRect.left,
-      width: buttonRect.width,
-    };
-  };
-
-  const updatePill = (shouldAnimate: boolean) => {
-    const next = measurePill();
-    if (!next) return;
-
-    if (!pillReady) {
-      pillLeft.set(next.left, { instant: true });
-      pillWidth.set(next.width, { instant: true });
-      pillReady = true;
-      return;
-    }
-
-    if (!shouldAnimate || !hasAnimated) {
-      pillLeft.set(next.left, { instant: true });
-      pillWidth.set(next.width, { instant: true });
-      return;
-    }
-
-    pillLeft.set(next.left);
-    pillWidth.set(next.width);
-  };
-
-  $effect(() => {
-    value;
-    if (!pillReady) return;
-    updatePill(true);
+  let pillLeft = $derived.by(() => {
+    const i = options.findIndex((o: SegmentedControlOption) => o.value === value);
+    return `calc(${PADDING}px + ${i} * (100% - ${PADDING * 2}px) / ${options.length})`;
   });
 
-  $effect(() => {
-    if (!containerRef || typeof ResizeObserver === 'undefined') return;
+  let pillWidth = $derived(`calc((100% - ${PADDING * 2}px) / ${options.length})`);
 
-    requestAnimationFrame(() => {
-      updatePill(false);
+  let transition = $derived.by(() => {
+    if (!hasAnimated) {
       hasAnimated = true;
-    });
-
-    const ro = new ResizeObserver(() => updatePill(false));
-    ro.observe(containerRef);
-
-    return () => {
-      ro.disconnect();
-    };
+      return 'none';
+    }
+    return 'left 0.2s cubic-bezier(0.25, 1, 0.5, 1), width 0.2s cubic-bezier(0.25, 1, 0.5, 1)';
   });
 </script>
 
-<div bind:this={containerRef} class="dialkit-segmented">
+<div class="dialkit-segmented">
   <div
     class="dialkit-segmented-pill"
-    style:left={`${pillLeft.current}px`}
-    style:width={`${pillWidth.current}px`}
-    style:visibility={pillReady ? 'visible' : 'hidden'}
-  />
+    style:left={pillLeft}
+    style:width={pillWidth}
+    style:transition={transition}
+  ></div>
 
   {#each options as option (option.value)}
     <button
-      use:buttonRef={option.value}
       onclick={() => onChange(option.value)}
       class="dialkit-segmented-button"
       data-active={String(value === option.value)}


### PR DESCRIPTION
### Problem

  When toggling a value (e.g. "Visible" to **On**), closing the DialKit panel, and reopening it, the pill background behind the active option is misaligned. This affects React,
   Solid, and Svelte.

  **Reproduction:**
  1. Open a DialKit panel with a toggle/segmented control
  2. Toggle the value to **On**
  3. Collapse the panel (click the icon)
  4. Reopen the panel
  5. The pill background behind "On" is offset

  ### Root cause

  The pill position was calculated via `getBoundingClientRect()` at mount time. When the panel reopens, it animates its width from 42px → 280px. The SegmentedControl mounts
  mid-animation, so the measurement is taken against an intermediate layout — not the final one. Since the buttons are `flex: 1`, their positions shift as the parent expands,
  but the pill stays at the stale offset.

  ### Fix

  Replace JavaScript-based `getBoundingClientRect()` measurement with CSS `calc()` positioning. Since all buttons use `flex: 1` (equal width), the pill position can be derived
  mathematically from the active index:

  left: calc(2px + activeIndex * (100% - 4px) / count)
  width: calc((100% - 4px) / count)

  CSS `calc()` resolves at paint time, so the pill is always correctly positioned regardless of parent animation state. CSS transitions replace framer-motion springs for the
  pill slide animation.

  This also removes the `motion` import from SegmentedControl in React and Solid.

  ### Demo

  | | URL |
  |---|---|
  | **React (fixed)** | https://dialkit-test.pages.dev |
  | **Solid (fixed)** | https://dialkit-test-solid.pages.dev |
  | **Svelte (fixed)** | https://dialkit-test-svelte.pages.dev |

  ### Changes

  | File | Framework | What changed |
  |---|---|---|
  | `src/components/SegmentedControl.tsx` | React | Replaced `useLayoutEffect` + `getBoundingClientRect` + `motion.div` with CSS `calc()` + CSS transition |
  | `src/solid/components/SegmentedControl.tsx` | Solid | Replaced `createSignal` + `animate()` + `ResizeObserver` + `measurePill()` with CSS `calc()` + CSS transition |
  | `src/svelte/components/SegmentedControl.svelte` | Svelte | Replaced `Spring` + `$effect` + `ResizeObserver` + `measurePill()` with `$derived` CSS `calc()` + CSS transition