### PR TITLE
feat: add configurable position picker for popover mode

### DIFF
--- a/src/components/DialRoot.tsx
+++ b/src/components/DialRoot.tsx
@@ -1,21 +1,25 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { DialStore, PanelConfig } from '../store/DialStore';
+import { DialStore, PanelConfig, loadPosition, savePosition } from '../store/DialStore';
+import type { DialPosition } from '../store/DialStore';
 import { Panel } from './Panel';
 
-export type DialPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+export type { DialPosition };
 export type DialMode = 'popover' | 'inline';
 
 interface DialRootProps {
   position?: DialPosition;
   defaultOpen?: boolean;
   mode?: DialMode;
+  positionPicker?: boolean;
 }
 
-export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'popover' }: DialRootProps) {
+export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'popover', positionPicker = false }: DialRootProps) {
   const [panels, setPanels] = useState<PanelConfig[]>([]);
   const [mounted, setMounted] = useState(false);
   const inline = mode === 'inline';
+  const showPicker = positionPicker && !inline;
+  const [currentPosition, setCurrentPosition] = useState<DialPosition>(() => showPicker ? loadPosition(position) : position);
 
   // Subscribe to global panel changes
   useEffect(() => {
@@ -29,6 +33,14 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
     return unsubscribe;
   }, []);
 
+  const handlePositionChange = useCallback((pos: DialPosition) => {
+    setCurrentPosition(pos);
+    savePosition(pos);
+  }, []);
+
+  // Derive transform-origin from position for open/close animation
+  const growDirection = currentPosition.startsWith('bottom') ? 'up' : 'down';
+
   // Don't render on server
   if (!mounted || typeof window === 'undefined') {
     return null;
@@ -41,9 +53,21 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
 
   const content = (
     <div className="dialkit-root" data-mode={mode}>
-      <div className="dialkit-panel" data-position={inline ? undefined : position} data-mode={mode}>
+      <div
+        className="dialkit-panel"
+        data-position={inline ? undefined : currentPosition}
+        data-mode={mode}
+      >
         {panels.map((panel) => (
-          <Panel key={panel.id} panel={panel} defaultOpen={inline || defaultOpen} inline={inline} />
+          <Panel
+            key={panel.id}
+            panel={panel}
+            defaultOpen={inline || defaultOpen}
+            inline={inline}
+            growDirection={!inline ? growDirection : undefined}
+            currentPosition={showPicker ? currentPosition : undefined}
+            onPositionChange={showPicker ? handlePositionChange : undefined}
+          />
         ))}
       </div>
     </div>

--- a/src/components/Folder.tsx
+++ b/src/components/Folder.tsx
@@ -9,9 +9,11 @@ interface FolderProps {
   inline?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   toolbar?: ReactNode;
+  growDirection?: 'up' | 'down';
+  compactToolbar?: boolean;
 }
 
-export function Folder({ title, children, defaultOpen = true, isRoot = false, inline = false, onOpenChange, toolbar }: FolderProps) {
+export function Folder({ title, children, defaultOpen = true, isRoot = false, inline = false, onOpenChange, toolbar, growDirection, compactToolbar }: FolderProps) {
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const [isCollapsed, setIsCollapsed] = useState(!defaultOpen);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -93,7 +95,7 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, in
         </div>
 
         {isRoot && toolbar && isOpen && (
-          <div className="dialkit-panel-toolbar" onClick={(e) => e.stopPropagation()}>
+          <div className="dialkit-panel-toolbar" data-compact={compactToolbar ? '' : undefined} onClick={(e) => e.stopPropagation()}>
             {toolbar}
           </div>
         )}
@@ -125,9 +127,13 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, in
       );
     }
 
-    const panelStyle = isOpen
+    const panelStyle: Record<string, any> = isOpen
       ? { width: 280, height: contentHeight !== undefined ? contentHeight + 24 : 'auto' as const, borderRadius: 14, boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)', cursor: undefined as string | undefined }
       : { width: 42, height: 42, borderRadius: 21, boxShadow: '0 4px 16px rgba(0, 0, 0, 0.25)', overflow: 'hidden' as const, cursor: 'pointer' as const };
+
+    if (growDirection === 'up') {
+      panelStyle.transformOrigin = 'bottom right';
+    }
 
     return (
       <motion.div

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,6 +1,7 @@
 import { useState, useSyncExternalStore } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
-import { DialStore, ControlMeta, PanelConfig, SpringConfig, TransitionConfig } from '../store/DialStore';
+import { DialStore, DIAL_POSITIONS } from '../store/DialStore';
+import type { ControlMeta, PanelConfig, SpringConfig, TransitionConfig, DialPosition } from '../store/DialStore';
 import { Folder } from './Folder';
 import { Slider } from './Slider';
 import { Toggle } from './Toggle';
@@ -15,9 +16,12 @@ interface PanelProps {
   panel: PanelConfig;
   defaultOpen?: boolean;
   inline?: boolean;
+  growDirection?: 'up' | 'down';
+  currentPosition?: DialPosition;
+  onPositionChange?: (position: DialPosition) => void;
 }
 
-export function Panel({ panel, defaultOpen = true, inline = false }: PanelProps) {
+export function Panel({ panel, defaultOpen = true, inline = false, growDirection, currentPosition, onPositionChange }: PanelProps) {
   const [copied, setCopied] = useState(false);
   const [isPanelOpen, setIsPanelOpen] = useState(defaultOpen);
 
@@ -164,8 +168,22 @@ Apply these values as the new defaults in the useDialKit call.`;
 
   const iconTransition = { type: 'spring' as const, visualDuration: 0.4, bounce: 0.1 };
 
+  const positionPicker = currentPosition && onPositionChange ? (
+    <div className="dialkit-position-picker" title="Panel position">
+      {DIAL_POSITIONS.map((pos) => (
+        <button
+          key={pos}
+          className="dialkit-position-dot"
+          data-active={currentPosition === pos ? 'true' : undefined}
+          onClick={() => onPositionChange(pos)}
+        />
+      ))}
+    </div>
+  ) : null;
+
   const toolbar = (
     <>
+      {positionPicker}
       <motion.button
         className="dialkit-toolbar-add"
         onClick={handleAddPreset}
@@ -240,7 +258,7 @@ Apply these values as the new defaults in the useDialKit call.`;
 
   return (
     <div className="dialkit-panel-wrapper">
-      <Folder title={panel.name} defaultOpen={defaultOpen} isRoot={true} inline={inline} onOpenChange={setIsPanelOpen} toolbar={toolbar}>
+      <Folder title={panel.name} defaultOpen={defaultOpen} isRoot={true} inline={inline} onOpenChange={setIsPanelOpen} toolbar={toolbar} growDirection={growDirection} compactToolbar={!!currentPosition}>
         {renderControls()}
       </Folder>
     </div>

--- a/src/solid/components/DialRoot.tsx
+++ b/src/solid/components/DialRoot.tsx
@@ -1,22 +1,34 @@
 import { createSignal, onMount, onCleanup, Show, For } from 'solid-js';
 import { Portal } from 'solid-js/web';
-import { DialStore } from '../../store/DialStore';
-import type { PanelConfig } from '../../store/DialStore';
+import { DialStore, loadPosition, savePosition } from '../../store/DialStore';
+import type { PanelConfig, DialPosition } from '../../store/DialStore';
 import { Panel } from './Panel';
 
-export type DialPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+export type { DialPosition };
 export type DialMode = 'popover' | 'inline';
 
 interface DialRootProps {
   position?: DialPosition;
   defaultOpen?: boolean;
   mode?: DialMode;
+  positionPicker?: boolean;
 }
 
 export function DialRoot(props: DialRootProps) {
   const [panels, setPanels] = createSignal<PanelConfig[]>([]);
   const [mounted, setMounted] = createSignal(false);
   const inline = () => (props.mode ?? 'popover') === 'inline';
+  const showPicker = () => (props.positionPicker ?? false) && !inline();
+  const [currentPosition, setCurrentPosition] = createSignal<DialPosition>(
+    showPicker() ? loadPosition(props.position ?? 'top-right') : (props.position ?? 'top-right')
+  );
+
+  const growDirection = () => currentPosition().startsWith('bottom') ? 'up' as const : 'down' as const;
+
+  const handlePositionChange = (pos: DialPosition) => {
+    setCurrentPosition(pos);
+    savePosition(pos);
+  };
 
   onMount(() => {
     setMounted(true);
@@ -29,9 +41,22 @@ export function DialRoot(props: DialRootProps) {
 
   const content = () => (
     <div class="dialkit-root" data-mode={props.mode ?? 'popover'}>
-      <div class="dialkit-panel" data-position={inline() ? undefined : (props.position ?? 'top-right')} data-mode={props.mode ?? 'popover'}>
+      <div
+        class="dialkit-panel"
+        data-position={inline() ? undefined : currentPosition()}
+        data-mode={props.mode ?? 'popover'}
+      >
         <For each={panels()}>
-          {(panel) => <Panel panel={panel} defaultOpen={inline() || (props.defaultOpen ?? true)} inline={inline()} />}
+          {(panel) => (
+            <Panel
+              panel={panel}
+              defaultOpen={inline() || (props.defaultOpen ?? true)}
+              inline={inline()}
+              growDirection={!inline() ? growDirection() : undefined}
+              currentPosition={showPicker() ? currentPosition() : undefined}
+              onPositionChange={showPicker() ? handlePositionChange : undefined}
+            />
+          )}
         </For>
       </div>
     </div>

--- a/src/solid/components/Folder.tsx
+++ b/src/solid/components/Folder.tsx
@@ -9,6 +9,8 @@ interface FolderProps {
   inline?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   toolbar?: JSX.Element;
+  growDirection?: 'up' | 'down';
+  compactToolbar?: boolean;
 }
 
 export function Folder(props: FolderProps) {
@@ -169,7 +171,7 @@ export function Folder(props: FolderProps) {
         </div>
 
         <Show when={props.isRoot && props.toolbar && isOpen()}>
-          <div class="dialkit-panel-toolbar" onClick={(e) => e.stopPropagation()}>
+          <div class="dialkit-panel-toolbar" data-compact={props.compactToolbar ? '' : undefined} onClick={(e) => e.stopPropagation()}>
             {props.toolbar}
           </div>
         </Show>
@@ -249,6 +251,8 @@ export function Folder(props: FolderProps) {
 
       panelRef.style.cursor = open ? '' : 'pointer';
       panelRef.style.overflow = open ? '' : 'hidden';
+
+      panelRef.style.transformOrigin = props.growDirection === 'up' ? 'bottom right' : '';
 
       if (!rootPanelInitialized) {
         rootPanelInitialized = true;

--- a/src/solid/components/Panel.tsx
+++ b/src/solid/components/Panel.tsx
@@ -1,7 +1,7 @@
 import { createSignal, createEffect, onMount, onCleanup, Show, For, JSX } from 'solid-js';
 import { animate } from 'motion';
-import { DialStore } from '../../store/DialStore';
-import type { ControlMeta, PanelConfig, SpringConfig, DialValue } from '../../store/DialStore';
+import { DialStore, DIAL_POSITIONS } from '../../store/DialStore';
+import type { ControlMeta, PanelConfig, SpringConfig, DialValue, DialPosition } from '../../store/DialStore';
 import { Folder } from './Folder';
 import { Slider } from './Slider';
 import { Toggle } from './Toggle';
@@ -15,6 +15,9 @@ interface PanelProps {
   panel: PanelConfig;
   defaultOpen?: boolean;
   inline?: boolean;
+  growDirection?: 'up' | 'down';
+  currentPosition?: DialPosition;
+  onPositionChange?: (position: DialPosition) => void;
 }
 
 export function Panel(props: PanelProps) {
@@ -229,8 +232,21 @@ export function Panel(props: PanelProps) {
     );
   };
 
+  const positionPicker = () => props.currentPosition && props.onPositionChange ? (
+    <div class="dialkit-position-picker" title="Panel position">
+      {DIAL_POSITIONS.map((pos) => (
+        <button
+          class="dialkit-position-dot"
+          data-active={props.currentPosition === pos ? 'true' : undefined}
+          onClick={() => props.onPositionChange!(pos)}
+        />
+      ))}
+    </div>
+  ) : null;
+
   const toolbar = (
     <>
+      {positionPicker()}
       <button
         ref={addButtonRef}
         class="dialkit-toolbar-add"
@@ -296,7 +312,7 @@ export function Panel(props: PanelProps) {
 
   return (
     <div class="dialkit-panel-wrapper">
-      <Folder title={props.panel.name} defaultOpen={props.defaultOpen ?? true} isRoot={true} inline={props.inline ?? false} onOpenChange={setIsPanelOpen} toolbar={toolbar}>
+      <Folder title={props.panel.name} defaultOpen={props.defaultOpen ?? true} isRoot={true} inline={props.inline ?? false} onOpenChange={setIsPanelOpen} toolbar={toolbar} growDirection={props.growDirection} compactToolbar={!!props.currentPosition}>
         {renderControls()}
       </Folder>
     </div>

--- a/src/store/DialStore.ts
+++ b/src/store/DialStore.ts
@@ -655,3 +655,21 @@ class DialStoreClass {
 
 // Singleton instance
 export const DialStore = new DialStoreClass();
+
+// Position utilities (shared across React, Solid, Svelte)
+export type DialPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
+export const DIAL_POSITIONS: DialPosition[] = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+
+const POSITION_STORAGE_KEY = 'dialkit-position';
+
+export function loadPosition(fallback: DialPosition): DialPosition {
+  try {
+    const stored = localStorage.getItem(POSITION_STORAGE_KEY);
+    if (stored && DIAL_POSITIONS.includes(stored as DialPosition)) return stored as DialPosition;
+  } catch {}
+  return fallback;
+}
+
+export function savePosition(pos: DialPosition): void {
+  try { localStorage.setItem(POSITION_STORAGE_KEY, pos); } catch {}
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -39,6 +39,39 @@
   overflow: visible;
 }
 
+/* Position picker - 2x2 grid of corner dots */
+.dialkit-position-picker {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  width: var(--dial-row-height);
+  height: var(--dial-row-height);
+  padding: 10px;
+  flex-shrink: 0;
+  background: var(--dial-surface);
+  border-radius: var(--dial-radius);
+  cursor: default;
+}
+
+.dialkit-position-dot {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: var(--dial-text-tertiary);
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.dialkit-position-dot:hover {
+  background: var(--dial-text-secondary);
+}
+
+.dialkit-position-dot[data-active] {
+  background: var(--dial-text-root);
+}
+
 /* Inline mode */
 .dialkit-root[data-mode="inline"] {
   height: 100%;
@@ -603,6 +636,7 @@
   gap: 6px;
   height: var(--dial-row-height);
   margin-bottom: 6px;
+  overflow: hidden;
 }
 
 .dialkit-toolbar-add {
@@ -647,6 +681,15 @@
   border-radius: var(--dial-radius);
   cursor: pointer;
   transition: background 0.15s;
+}
+
+/* Compact copy button when position picker is present */
+.dialkit-panel-toolbar[data-compact] .dialkit-toolbar-copy {
+  width: var(--dial-row-height);
+  padding: 0;
+  justify-content: center;
+  font-size: 0;
+  gap: 0;
 }
 
 .dialkit-toolbar-copy:hover {
@@ -885,6 +928,7 @@
 .dialkit-preset-manager {
   position: relative;
   flex: 1;
+  min-width: 0;
 }
 
 .dialkit-preset-trigger {

--- a/src/svelte/components/DialRoot.svelte
+++ b/src/svelte/components/DialRoot.svelte
@@ -1,23 +1,33 @@
 <script lang="ts">
-  import { DialStore } from 'dialkit/store';
-  import type { PanelConfig } from 'dialkit/store';
+  import { DialStore, loadPosition, savePosition } from 'dialkit/store';
+  import type { PanelConfig, DialPosition } from 'dialkit/store';
   import { themeCSS } from '../theme-css';
   import Portal from '../Portal.svelte';
   import Panel from './Panel.svelte';
 
-  export type DialPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
   export type DialMode = 'popover' | 'inline';
 
-  let { position = 'top-right', defaultOpen = true, mode = 'popover' } = $props<{
+  let { position = 'top-right', defaultOpen = true, mode = 'popover', positionPicker = false } = $props<{
     position?: DialPosition;
     defaultOpen?: boolean;
     mode?: DialMode;
+    positionPicker?: boolean;
   }>();
 
   const inline = $derived(mode === 'inline');
+  const showPicker = $derived(positionPicker && !inline);
 
   let panels = $state<PanelConfig[]>([]);
   let mounted = $state(false);
+
+  let currentPosition = $state<DialPosition>(positionPicker && mode !== 'inline' ? loadPosition(position) : position);
+
+  const growDirection = $derived(currentPosition.startsWith('bottom') ? 'up' as const : 'down' as const);
+
+  function handlePositionChange(pos: DialPosition) {
+    currentPosition = pos;
+    savePosition(pos);
+  }
 
   $effect(() => {
     if (typeof document === 'undefined') return;
@@ -47,9 +57,20 @@
 {#if mounted && panels.length > 0}
   {#snippet content()}
     <div class="dialkit-root" data-mode={mode}>
-      <div class="dialkit-panel" data-mode={mode} data-position={inline ? undefined : position}>
+      <div
+        class="dialkit-panel"
+        data-mode={mode}
+        data-position={inline ? undefined : currentPosition}
+      >
         {#each panels as panel (panel.id)}
-          <Panel {panel} defaultOpen={inline || defaultOpen} {inline} />
+          <Panel
+            {panel}
+            defaultOpen={inline || defaultOpen}
+            {inline}
+            growDirection={!inline ? growDirection : undefined}
+            currentPosition={showPicker ? currentPosition : undefined}
+            onPositionChange={showPicker ? handlePositionChange : undefined}
+          />
         {/each}
       </div>
     </div>

--- a/src/svelte/components/Folder.svelte
+++ b/src/svelte/components/Folder.svelte
@@ -12,6 +12,8 @@
     onOpenChange,
     toolbar,
     children,
+    growDirection,
+    compactToolbar,
   } = $props<{
     title: string;
     defaultOpen?: boolean;
@@ -20,6 +22,8 @@
     onOpenChange?: (isOpen: boolean) => void;
     toolbar?: Snippet;
     children?: Snippet;
+    growDirection?: 'up' | 'down';
+    compactToolbar?: boolean;
   }>();
 
   let isOpen = $state(defaultOpen);
@@ -95,7 +99,8 @@
     `width:${panelWidth.current}px;height:${panelHeight.current}px;border-radius:${panelRadius.current}px;` +
       `box-shadow:${isOpen ? '0 8px 32px rgba(0, 0, 0, 0.5)' : '0 4px 16px rgba(0, 0, 0, 0.25)'};` +
       `cursor:${isOpen ? '' : 'pointer'};overflow:${isOpen ? '' : 'hidden'};` +
-      `transform:scale(${panelScale.current});`
+      `transform:scale(${panelScale.current});` +
+      (growDirection === 'up' ? 'transform-origin:bottom right;' : '')
   );
 </script>
 
@@ -109,7 +114,7 @@
           </div>
         </div>
 
-        <div class="dialkit-panel-toolbar" onclick={(e) => e.stopPropagation()}>
+        <div class="dialkit-panel-toolbar" data-compact={compactToolbar ? '' : undefined} onclick={(e) => e.stopPropagation()}>
           {#if toolbar}{@render toolbar()}{/if}
         </div>
       </div>
@@ -155,7 +160,7 @@
         </div>
 
         {#if isOpen}
-          <div class="dialkit-panel-toolbar" onclick={(e) => e.stopPropagation()}>
+          <div class="dialkit-panel-toolbar" data-compact={compactToolbar ? '' : undefined} onclick={(e) => e.stopPropagation()}>
             {#if toolbar}{@render toolbar()}{/if}
           </div>
         {/if}

--- a/src/svelte/components/Panel.svelte
+++ b/src/svelte/components/Panel.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { Spring } from 'svelte/motion';
-  import { DialStore } from 'dialkit/store';
-  import type { DialValue, PanelConfig, Preset } from 'dialkit/store';
+  import { DialStore, DIAL_POSITIONS } from 'dialkit/store';
+  import type { DialValue, PanelConfig, Preset, DialPosition } from 'dialkit/store';
   import Folder from './Folder.svelte';
   import PresetManager from './PresetManager.svelte';
   import ControlRenderer from './ControlRenderer.svelte';
 
-  let { panel, defaultOpen = true, inline = false } = $props<{ panel: PanelConfig; defaultOpen?: boolean; inline?: boolean }>();
+  let { panel, defaultOpen = true, inline = false, growDirection, currentPosition, onPositionChange } = $props<{ panel: PanelConfig; defaultOpen?: boolean; inline?: boolean; growDirection?: 'up' | 'down'; currentPosition?: DialPosition; onPositionChange?: (pos: DialPosition) => void }>();
 
   let copied = $state(false);
   let isPanelOpen = $state(defaultOpen);
@@ -71,8 +71,19 @@
 </script>
 
 <div class="dialkit-panel-wrapper">
-  <Folder title={panel.name} {defaultOpen} isRoot={true} {inline} onOpenChange={(open) => (isPanelOpen = open)}>
+  <Folder title={panel.name} {defaultOpen} isRoot={true} {inline} onOpenChange={(open) => (isPanelOpen = open)} {growDirection} compactToolbar={!!currentPosition}>
     {#snippet toolbar()}
+      {#if currentPosition && onPositionChange}
+        <div class="dialkit-position-picker" title="Panel position">
+          {#each DIAL_POSITIONS as pos}
+            <button
+              class="dialkit-position-dot"
+              data-active={currentPosition === pos ? 'true' : undefined}
+              onclick={() => onPositionChange(pos)}
+            ></button>
+          {/each}
+        </div>
+      {/if}
       <button
         class="dialkit-toolbar-add"
         onclick={handleAddPreset}

--- a/src/svelte/index.ts
+++ b/src/svelte/index.ts
@@ -4,7 +4,7 @@ export type { CreateDialOptions, DialKitValues } from './createDialKit.svelte';
 
 // Root component
 export { default as DialRoot } from './components/DialRoot.svelte';
-export type { DialPosition, DialMode } from './components/DialRoot.svelte';
+export type { DialMode } from './components/DialRoot.svelte';
 
 // Component exports
 export { default as Slider } from './components/Slider.svelte';
@@ -36,4 +36,5 @@ export type {
   ResolvedValues,
   ControlMeta,
   PanelConfig,
+  DialPosition,
 } from 'dialkit/store';


### PR DESCRIPTION
## Summary

  Adds an opt-in position picker to the DialKit popover panel, allowing users to switch between all four corners at runtime. Addresses [joshpuckett/dialkit#20](https://github.com/joshpuckett/dialkit/issues/20).

  - **`positionPicker` prop** on `<DialRoot>` (default `false`) — opt-in, no breaking changes
  - **2x2 dot grid** in the toolbar to switch corners (top-left, top-right, bottom-left, bottom-right)
  - **Position persists** to `localStorage` across page reloads
  - **Compact toolbar** when picker is active — copy button becomes icon-only to save space
  - **Transform-origin** adjusts for bottom positions so open/close animations anchor correctly
  - **Shared utilities** in `DialStore` — `loadPosition`, `savePosition`, `DIAL_POSITIONS` used by all frameworks
  - Implemented across **React, Solid, and Svelte**

  ## Usage

  ```tsx
  // Default — no position picker, behaves exactly as before
  <DialRoot position="top-right" />

  // Opt-in — position picker with localStorage persistence
  <DialRoot position="top-right" positionPicker />
```

Demo : https://dialkit-position-demo.pages.dev/