### PR TITLE
Add light/dark/system theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ const values = useDialKit('Controls', {
 | `position` | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'` |
 | `defaultOpen` | `boolean` | `true` |
 | `mode` | `'popover' \| 'inline'` | `'popover'` |
+| `theme` | `'light' \| 'dark' \| 'system'` | — |
 
 Mount once at your app root. In the default `popover` mode, the panel renders via a portal on `document.body`. It collapses to a small icon button and expands to 280px wide on click.
 
@@ -286,6 +287,18 @@ Use `mode="inline"` to render DialKit directly in your layout instead of as a fl
 ```
 
 In inline mode, the `position` prop is ignored and the collapse-to-icon behavior is disabled.
+
+### Theming
+
+Pass `theme` to switch between light and dark appearances:
+
+```tsx
+<DialRoot theme="dark" />    // always dark (default look)
+<DialRoot theme="light" />   // always light
+<DialRoot theme="system" />  // follows OS preference
+```
+
+When set to `"system"`, the panel listens to `prefers-color-scheme` and updates live if the user changes their OS appearance. When `theme` is omitted, the panel uses the original dark style.
 
 ---
 

--- a/src/components/DialRoot.tsx
+++ b/src/components/DialRoot.tsx
@@ -5,17 +5,40 @@ import { Panel } from './Panel';
 
 export type DialPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
 export type DialMode = 'popover' | 'inline';
+export type DialTheme = 'light' | 'dark' | 'system';
 
 interface DialRootProps {
   position?: DialPosition;
   defaultOpen?: boolean;
   mode?: DialMode;
+  theme?: DialTheme;
 }
 
-export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'popover' }: DialRootProps) {
+function useResolvedTheme(theme?: DialTheme): 'light' | 'dark' | undefined {
+  const [systemDark, setSystemDark] = useState(() =>
+    typeof window !== 'undefined'
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+      : true
+  );
+
+  useEffect(() => {
+    if (theme !== 'system') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [theme]);
+
+  if (!theme) return undefined;
+  if (theme === 'system') return systemDark ? 'dark' : 'light';
+  return theme;
+}
+
+export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'popover', theme }: DialRootProps) {
   const [panels, setPanels] = useState<PanelConfig[]>([]);
   const [mounted, setMounted] = useState(false);
   const inline = mode === 'inline';
+  const resolvedTheme = useResolvedTheme(theme);
 
   // Subscribe to global panel changes
   useEffect(() => {
@@ -40,7 +63,7 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
   }
 
   const content = (
-    <div className="dialkit-root" data-mode={mode}>
+    <div className="dialkit-root" data-mode={mode} data-theme={resolvedTheme}>
       <div className="dialkit-panel" data-position={inline ? undefined : position} data-mode={mode}>
         {panels.map((panel) => (
           <Panel key={panel.id} panel={panel} defaultOpen={inline || defaultOpen} inline={inline} />

--- a/src/components/EasingVisualization.tsx
+++ b/src/components/EasingVisualization.tsx
@@ -40,12 +40,12 @@ export function EasingVisualization({ easing }: EasingVisualizationProps) {
     >
       <line
         x1={start.x} y1={start.y} x2={end.x} y2={end.y}
-        stroke="rgba(255, 255, 255, 0.15)"
+        style={{ stroke: 'var(--dial-viz-line)' }}
         strokeWidth="1"
         strokeDasharray="4,4"
       />
 
-      <path d={curvePath} fill="none" stroke="rgba(255, 255, 255, 0.6)" strokeWidth="2" strokeLinecap="round" />
+      <path d={curvePath} fill="none" style={{ stroke: 'var(--dial-viz-curve)' }} strokeWidth="2" strokeLinecap="round" />
     </svg>
   );
 }

--- a/src/components/Folder.tsx
+++ b/src/components/Folder.tsx
@@ -126,8 +126,8 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, in
     }
 
     const panelStyle = isOpen
-      ? { width: 280, height: contentHeight !== undefined ? contentHeight + 24 : 'auto' as const, borderRadius: 14, boxShadow: '0 8px 32px rgba(0, 0, 0, 0.5)', cursor: undefined as string | undefined }
-      : { width: 42, height: 42, borderRadius: 21, boxShadow: '0 4px 16px rgba(0, 0, 0, 0.25)', overflow: 'hidden' as const, cursor: 'pointer' as const };
+      ? { width: 280, height: contentHeight !== undefined ? contentHeight + 24 : 'auto' as const, borderRadius: 14, boxShadow: 'var(--dial-panel-shadow-open)', cursor: undefined as string | undefined }
+      : { width: 42, height: 42, borderRadius: 21, boxShadow: 'var(--dial-panel-shadow-collapsed)', overflow: 'hidden' as const, cursor: 'pointer' as const };
 
     return (
       <motion.div

--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -341,8 +341,8 @@ export function Slider({
         : 0.5;
 
   const fillBackground = isActive
-    ? 'rgba(255, 255, 255, 0.15)'
-    : 'rgba(255, 255, 255, 0.11)';
+    ? 'var(--dial-slider-fill-active)'
+    : 'var(--dial-slider-fill)';
 
   // The ≤ 10 threshold separates discrete sliders
   // (like step=2 on a 0–10 range → 5 steps) from continuous ones.
@@ -397,7 +397,7 @@ export function Slider({
           style={{
             left: handleLeft,
             y: '-50%',
-            background: 'rgba(255, 255, 255, 0.9)',
+            background: 'var(--dial-slider-handle)',
           }}
           animate={{
             opacity: handleOpacity,

--- a/src/components/SpringVisualization.tsx
+++ b/src/components/SpringVisualization.tsx
@@ -80,8 +80,8 @@ export function SpringVisualization({ spring, isSimpleMode }: SpringVisualizatio
     const x = (width / 4) * i;
     const y = (height / 4) * i;
     gridLines.push(
-      <line key={`v-${i}`} x1={x} y1={0} x2={x} y2={height} stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />,
-      <line key={`h-${i}`} x1={0} y1={y} x2={width} y2={y} stroke="rgba(255, 255, 255, 0.08)" strokeWidth="1" />
+      <line key={`v-${i}`} x1={x} y1={0} x2={x} y2={height} style={{ stroke: 'var(--dial-viz-grid)' }} strokeWidth="1" />,
+      <line key={`h-${i}`} x1={0} y1={y} x2={width} y2={y} style={{ stroke: 'var(--dial-viz-grid)' }} strokeWidth="1" />
     );
   }
 
@@ -93,14 +93,14 @@ export function SpringVisualization({ spring, isSimpleMode }: SpringVisualizatio
         y1={height / 2}
         x2={width}
         y2={height / 2}
-        stroke="rgba(255, 255, 255, 0.15)"
+        style={{ stroke: 'var(--dial-viz-line)' }}
         strokeWidth="1"
         strokeDasharray="4,4"
       />
       <path
         d={pathData}
         fill="none"
-        stroke="rgba(255, 255, 255, 0.6)"
+        style={{ stroke: 'var(--dial-viz-curve)' }}
         strokeWidth="2"
         strokeLinecap="round"
         strokeLinejoin="round"

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ export type { UseDialOptions } from './hooks/useDialKit';
 
 // Root component (user mounts once)
 export { DialRoot } from './components/DialRoot';
-export type { DialPosition, DialMode } from './components/DialRoot';
+export type { DialPosition, DialMode, DialTheme } from './components/DialRoot';
 
 // Individual components (for advanced usage)
 export { Slider } from './components/Slider';

--- a/src/solid/components/DialRoot.tsx
+++ b/src/solid/components/DialRoot.tsx
@@ -6,17 +6,30 @@ import { Panel } from './Panel';
 
 export type DialPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
 export type DialMode = 'popover' | 'inline';
+export type DialTheme = 'light' | 'dark' | 'system';
 
 interface DialRootProps {
   position?: DialPosition;
   defaultOpen?: boolean;
   mode?: DialMode;
+  theme?: DialTheme;
 }
 
 export function DialRoot(props: DialRootProps) {
   const [panels, setPanels] = createSignal<PanelConfig[]>([]);
   const [mounted, setMounted] = createSignal(false);
+  const [systemDark, setSystemDark] = createSignal(
+    typeof window !== 'undefined'
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+      : true
+  );
   const inline = () => (props.mode ?? 'popover') === 'inline';
+  const resolvedTheme = () => {
+    const t = props.theme;
+    if (!t) return undefined;
+    if (t === 'system') return systemDark() ? 'dark' : 'light';
+    return t;
+  };
 
   onMount(() => {
     setMounted(true);
@@ -24,11 +37,19 @@ export function DialRoot(props: DialRootProps) {
     const unsub = DialStore.subscribeGlobal(() => {
       setPanels(DialStore.getPanels());
     });
-    onCleanup(unsub);
+
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => setSystemDark(e.matches);
+    mq.addEventListener('change', handler);
+
+    onCleanup(() => {
+      unsub();
+      mq.removeEventListener('change', handler);
+    });
   });
 
   const content = () => (
-    <div class="dialkit-root" data-mode={props.mode ?? 'popover'}>
+    <div class="dialkit-root" data-mode={props.mode ?? 'popover'} data-theme={resolvedTheme()}>
       <div class="dialkit-panel" data-position={inline() ? undefined : (props.position ?? 'top-right')} data-mode={props.mode ?? 'popover'}>
         <For each={panels()}>
           {(panel) => <Panel panel={panel} defaultOpen={inline() || (props.defaultOpen ?? true)} inline={inline()} />}

--- a/src/solid/components/Folder.tsx
+++ b/src/solid/components/Folder.tsx
@@ -243,8 +243,8 @@ export function Folder(props: FolderProps) {
         height: open ? measuredOpenHeight : 42,
         borderRadius: open ? 14 : 21,
         boxShadow: open
-          ? '0 8px 32px rgba(0, 0, 0, 0.5)'
-          : '0 4px 16px rgba(0, 0, 0, 0.25)',
+          ? 'var(--dial-panel-shadow-open)'
+          : 'var(--dial-panel-shadow-collapsed)',
       };
 
       panelRef.style.cursor = open ? '' : 'pointer';

--- a/src/solid/components/Slider.tsx
+++ b/src/solid/components/Slider.tsx
@@ -358,7 +358,7 @@ export function Slider(props: SliderProps) {
   });
 
   const fillBackground = () =>
-    isActive() ? 'rgba(255, 255, 255, 0.15)' : 'rgba(255, 255, 255, 0.11)';
+    isActive() ? 'var(--dial-slider-fill-active)' : 'var(--dial-slider-fill)';
 
   const discreteSteps = () => (max() - min()) / step();
 
@@ -407,7 +407,7 @@ export function Slider(props: SliderProps) {
             left: `max(5px, calc(${fillPercent.get()}% - 9px))`,
             transform: 'translateY(-50%) scaleX(0.25) scaleY(1)',
             opacity: 0,
-            background: 'rgba(255, 255, 255, 0.9)',
+            background: 'var(--dial-slider-handle)',
           }}
         />
 

--- a/src/solid/components/SpringVisualization.tsx
+++ b/src/solid/components/SpringVisualization.tsx
@@ -81,8 +81,8 @@ export function SpringVisualization(props: SpringVisualizationProps) {
       const x = (width / 4) * i;
       const y = (height / 4) * i;
       lines.push(
-        <line x1={x} y1={0} x2={x} y2={height} stroke="rgba(255, 255, 255, 0.08)" stroke-width="1" />,
-        <line x1={0} y1={y} x2={width} y2={y} stroke="rgba(255, 255, 255, 0.08)" stroke-width="1" />
+        <line x1={x} y1={0} x2={x} y2={height} style={{ stroke: 'var(--dial-viz-grid)' }} stroke-width="1" />,
+        <line x1={0} y1={y} x2={width} y2={y} style={{ stroke: 'var(--dial-viz-grid)' }} stroke-width="1" />
       );
     }
     return lines;
@@ -96,14 +96,14 @@ export function SpringVisualization(props: SpringVisualizationProps) {
         y1={height / 2}
         x2={width}
         y2={height / 2}
-        stroke="rgba(255, 255, 255, 0.15)"
+        style={{ stroke: 'var(--dial-viz-line)' }}
         stroke-width="1"
         stroke-dasharray="4,4"
       />
       <path
         d={params()}
         fill="none"
-        stroke="rgba(255, 255, 255, 0.6)"
+        style={{ stroke: 'var(--dial-viz-curve)' }}
         stroke-width="2"
         stroke-linecap="round"
         stroke-linejoin="round"

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -4,7 +4,7 @@ export type { CreateDialOptions } from './createDialKit';
 
 // Root component
 export { DialRoot } from './components/DialRoot';
-export type { DialPosition, DialMode } from './components/DialRoot';
+export type { DialPosition, DialMode, DialTheme } from './components/DialRoot';
 
 // Component exports
 export { Slider } from './components/Slider';

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -26,10 +26,92 @@
   --dial-row-height: 36px;
   --dial-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 
+  /* Dividers */
+  --dial-divider: rgba(255, 255, 255, 0.06);
+
+  /* Active text (focus states, emphasized values) */
+  --dial-active-text: #fff;
+
+  /* Slider */
+  --dial-slider-fill: rgba(255, 255, 255, 0.11);
+  --dial-slider-fill-active: rgba(255, 255, 255, 0.15);
+  --dial-slider-handle: rgba(255, 255, 255, 0.9);
+  --dial-hashmark: rgba(255, 255, 255, 0);
+  --dial-hashmark-active: rgba(255, 255, 255, 0.15);
+
+  /* Toggle */
+  --dial-toggle-track-on: rgba(255, 255, 255, 0.3);
+  --dial-toggle-thumb: rgba(255, 255, 255, 0.8);
+
+  /* Segmented */
+  --dial-segmented-active: rgba(255, 255, 255, 0.8);
+
+  /* Visualization */
+  --dial-viz-grid: rgba(255, 255, 255, 0.08);
+  --dial-viz-line: rgba(255, 255, 255, 0.15);
+  --dial-viz-curve: rgba(255, 255, 255, 0.6);
+
+  /* Dropdowns */
+  --dial-dropdown-bg: #2a2a2a;
+  --dial-dropdown-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+
+  /* Panel shadows */
+  --dial-panel-shadow-open: 0 8px 32px rgba(0, 0, 0, 0.5);
+  --dial-panel-shadow-collapsed: 0 4px 16px rgba(0, 0, 0, 0.25);
+
+  /* Color swatch */
+  --dial-swatch-border: rgba(255, 255, 255, 0.2);
+
   /* Fonts */
   font-family: system-ui, -apple-system, 'SF Pro Display', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Light theme */
+.dialkit-root[data-theme="light"] {
+  --dial-surface: rgba(0, 0, 0, 0.04);
+  --dial-surface-hover: rgba(0, 0, 0, 0.07);
+  --dial-surface-active: rgba(0, 0, 0, 0.1);
+
+  --dial-text-root: #1a1a1a;
+  --dial-text-section: rgba(0, 0, 0, 0.55);
+  --dial-text-label: rgba(0, 0, 0, 0.55);
+  --dial-text-primary: rgba(0, 0, 0, 0.88);
+  --dial-text-secondary: rgba(0, 0, 0, 0.5);
+  --dial-text-tertiary: rgba(0, 0, 0, 0.32);
+
+  --dial-border: rgba(0, 0, 0, 0.1);
+  --dial-border-hover: rgba(0, 0, 0, 0.15);
+
+  --dial-glass-bg: #f5f5f5;
+  --dial-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+
+  --dial-divider: rgba(0, 0, 0, 0.08);
+  --dial-active-text: #1a1a1a;
+
+  --dial-slider-fill: rgba(0, 0, 0, 0.05);
+  --dial-slider-fill-active: rgba(0, 0, 0, 0.1);
+  --dial-slider-handle: rgba(0, 0, 0, 0.6);
+  --dial-hashmark: rgba(0, 0, 0, 0);
+  --dial-hashmark-active: rgba(0, 0, 0, 0.15);
+
+  --dial-toggle-track-on: rgba(0, 0, 0, 0.25);
+  --dial-toggle-thumb: rgba(0, 0, 0, 0.6);
+
+  --dial-segmented-active: rgba(0, 0, 0, 0.7);
+
+  --dial-viz-grid: rgba(0, 0, 0, 0.08);
+  --dial-viz-line: rgba(0, 0, 0, 0.15);
+  --dial-viz-curve: rgba(0, 0, 0, 0.5);
+
+  --dial-dropdown-bg: #e8e8e8;
+  --dial-dropdown-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+
+  --dial-panel-shadow-open: 0 8px 32px rgba(0, 0, 0, 0.1);
+  --dial-panel-shadow-collapsed: 0 4px 16px rgba(0, 0, 0, 0.06);
+
+  --dial-swatch-border: rgba(0, 0, 0, 0.2);
 }
 
 .dialkit-panel {
@@ -138,7 +220,7 @@
 .dialkit-folder {
   padding-bottom: 8px;
   margin-bottom: 8px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid var(--dial-divider);
 }
 
 .dialkit-folder:last-child:not(.dialkit-folder-root) {
@@ -155,7 +237,7 @@
 .dialkit-panel-header {
   padding-bottom: 6px;
   margin-bottom: 12px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-bottom: 1px solid var(--dial-divider);
 }
 
 .dialkit-folder-header {
@@ -230,7 +312,7 @@
   right: 12px;
   width: 16px;
   height: 16px;
-  color: #fff;
+  color: var(--dial-active-text);
   z-index: 1;
 }
 
@@ -247,8 +329,8 @@
 
 /* Non-root folders - top & bottom HR dividers */
 .dialkit-folder:not(.dialkit-folder-root) {
-  border-top: 1px solid rgba(255, 255, 255, 0.06);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  border-top: 1px solid var(--dial-divider);
+  border-bottom: 1px solid var(--dial-divider);
   margin-top: 4px;
   margin-bottom: 4px;
   padding-bottom: 0;
@@ -312,16 +394,16 @@
   height: 8px;
   border-radius: 999px;
   transform: translateX(-50%) translateY(-50%);
-  background: rgba(255, 255, 255, 0);
+  background: var(--dial-hashmark);
   transition: background 200ms;
 }
 
 .dialkit-slider-active .dialkit-slider-hashmark {
-  background: rgba(255, 255, 255, 0.15);
+  background: var(--dial-hashmark-active);
 }
 
 .dialkit-slider-active .dialkit-slider-value {
-  color: #fff;
+  color: var(--dial-active-text);
 }
 
 .dialkit-slider-fill {
@@ -394,7 +476,7 @@
 }
 
 .dialkit-slider-input:focus {
-  color: #fff;
+  color: var(--dial-active-text);
 }
 
 /* Segmented Control */
@@ -431,7 +513,7 @@
 }
 
 .dialkit-segmented-button[data-active="true"] {
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--dial-segmented-active);
 }
 
 .dialkit-segmented-button[data-active="false"] {
@@ -476,7 +558,7 @@
 }
 
 .dialkit-toggle[data-checked="true"] .dialkit-toggle-track {
-  background: rgba(255, 255, 255, 0.3);
+  background: var(--dial-toggle-track-on);
 }
 
 .dialkit-toggle-thumb {
@@ -485,7 +567,7 @@
   width: 16px;
   height: 16px;
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.8);
+  background: var(--dial-toggle-thumb);
 }
 
 /* Button Group */
@@ -702,7 +784,7 @@
 }
 
 .dialkit-text-input:focus {
-  color: #fff;
+  color: var(--dial-active-text);
 }
 
 .dialkit-text-input::placeholder {
@@ -779,7 +861,7 @@
   border-radius: var(--dial-radius);
   padding: 4px;
   z-index: 10000;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--dial-dropdown-shadow);
 }
 
 .dialkit-select-option {
@@ -857,14 +939,14 @@
 }
 
 .dialkit-color-hex-input:focus {
-  color: #fff;
+  color: var(--dial-active-text);
 }
 
 .dialkit-color-swatch {
   width: 20px;
   height: 20px;
   border-radius: 4px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--dial-swatch-border);
   cursor: pointer;
   transition: transform 0.15s;
 }
@@ -930,12 +1012,12 @@
 
 .dialkit-preset-dropdown {
   width: max-content;
-  background: #2a2a2a;
+  background: var(--dial-dropdown-bg);
   border: 1px solid var(--dial-border);
   border-radius: 12px;
   padding: 4px;
   z-index: 10000;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--dial-dropdown-shadow);
 }
 
 .dialkit-preset-list {
@@ -1005,7 +1087,7 @@
 .dialkit-preset-delete svg {
   width: 14px;
   height: 14px;
-  color: #fff;
+  color: var(--dial-active-text);
   pointer-events: none;
 }
 

--- a/src/svelte/components/DialRoot.svelte
+++ b/src/svelte/components/DialRoot.svelte
@@ -7,17 +7,36 @@
 
   export type DialPosition = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left';
   export type DialMode = 'popover' | 'inline';
+  export type DialTheme = 'light' | 'dark' | 'system';
 
-  let { position = 'top-right', defaultOpen = true, mode = 'popover' } = $props<{
+  let { position = 'top-right', defaultOpen = true, mode = 'popover', theme = undefined } = $props<{
     position?: DialPosition;
     defaultOpen?: boolean;
     mode?: DialMode;
+    theme?: DialTheme;
   }>();
 
   const inline = $derived(mode === 'inline');
 
   let panels = $state<PanelConfig[]>([]);
   let mounted = $state(false);
+  let systemDark = $state(
+    typeof window !== 'undefined'
+      ? window.matchMedia('(prefers-color-scheme: dark)').matches
+      : true
+  );
+
+  $effect(() => {
+    if (theme !== 'system' || typeof window === 'undefined') return;
+    const mq = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => { systemDark = e.matches; };
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  });
+
+  const resolvedTheme = $derived(
+    !theme ? undefined : theme === 'system' ? (systemDark ? 'dark' : 'light') : theme
+  );
 
   $effect(() => {
     if (typeof document === 'undefined') return;
@@ -46,7 +65,7 @@
 
 {#if mounted && panels.length > 0}
   {#snippet content()}
-    <div class="dialkit-root" data-mode={mode}>
+    <div class="dialkit-root" data-mode={mode} data-theme={resolvedTheme}>
       <div class="dialkit-panel" data-mode={mode} data-position={inline ? undefined : position}>
         {#each panels as panel (panel.id)}
           <Panel {panel} defaultOpen={inline || defaultOpen} {inline} />

--- a/src/svelte/components/Folder.svelte
+++ b/src/svelte/components/Folder.svelte
@@ -93,7 +93,7 @@
 
   const panelStyle = $derived(
     `width:${panelWidth.current}px;height:${panelHeight.current}px;border-radius:${panelRadius.current}px;` +
-      `box-shadow:${isOpen ? '0 8px 32px rgba(0, 0, 0, 0.5)' : '0 4px 16px rgba(0, 0, 0, 0.25)'};` +
+      `box-shadow:${isOpen ? 'var(--dial-panel-shadow-open)' : 'var(--dial-panel-shadow-collapsed)'};` +
       `cursor:${isOpen ? '' : 'pointer'};overflow:${isOpen ? '' : 'hidden'};` +
       `transform:scale(${panelScale.current});`
   );

--- a/src/svelte/components/Slider.svelte
+++ b/src/svelte/components/Slider.svelte
@@ -166,7 +166,7 @@
   });
 
   const fillBackground = $derived(
-    isActive ? 'rgba(255, 255, 255, 0.15)' : 'rgba(255, 255, 255, 0.11)'
+    isActive ? 'var(--dial-slider-fill-active)' : 'var(--dial-slider-fill)'
   );
 
   const discreteSteps = $derived((max - min) / step);
@@ -284,7 +284,7 @@
 
   const trackStyle = $derived(`width:calc(100% + ${Math.abs(rubberStretchPx.current)}px);transform:translateX(${rubberStretchPx.current < 0 ? rubberStretchPx.current : 0}px);`);
   const fillStyle = $derived(`background:${fillBackground};width:${fillPercent.current}%;transition:background 0.15s;`);
-  const handleStyle = $derived(`left:max(5px, calc(${fillPercent.current}% - 9px));opacity:${handleOpacityMv.current};transform:translateY(-50%) scaleX(${handleScaleXMv.current}) scaleY(${handleScaleYMv.current});background:rgba(255, 255, 255, 0.9);`);
+  const handleStyle = $derived(`left:max(5px, calc(${fillPercent.current}% - 9px));opacity:${handleOpacityMv.current};transform:translateY(-50%) scaleX(${handleScaleXMv.current}) scaleY(${handleScaleYMv.current});background:var(--dial-slider-handle);`);
 </script>
 
 <div bind:this={wrapperRef} class="dialkit-slider-wrapper">

--- a/src/svelte/components/SpringVisualization.svelte
+++ b/src/svelte/components/SpringVisualization.svelte
@@ -89,7 +89,7 @@
       y1={line.y1}
       x2={line.x2}
       y2={line.y2}
-      stroke="rgba(255, 255, 255, 0.08)"
+      style="stroke: var(--dial-viz-grid)"
       stroke-width="1"
     />
   {/each}
@@ -99,7 +99,7 @@
     y1={height / 2}
     x2={width}
     y2={height / 2}
-    stroke="rgba(255, 255, 255, 0.15)"
+    style="stroke: var(--dial-viz-line)"
     stroke-width="1"
     stroke-dasharray="4,4"
   />
@@ -107,7 +107,7 @@
   <path
     d={pathData}
     fill="none"
-    stroke="rgba(255, 255, 255, 0.6)"
+    style="stroke: var(--dial-viz-curve)"
     stroke-width="2"
     stroke-linecap="round"
     stroke-linejoin="round"

--- a/src/svelte/index.ts
+++ b/src/svelte/index.ts
@@ -4,7 +4,7 @@ export type { CreateDialOptions, DialKitValues } from './createDialKit.svelte';
 
 // Root component
 export { default as DialRoot } from './components/DialRoot.svelte';
-export type { DialPosition, DialMode } from './components/DialRoot.svelte';
+export type { DialPosition, DialMode, DialTheme } from './components/DialRoot.svelte';
 
 // Component exports
 export { default as Slider } from './components/Slider.svelte';


### PR DESCRIPTION
## Summary
- Adds a `theme` prop to `DialRoot` accepting `'light'`, `'dark'`, or `'system'` across React, Svelte, and Solid
- Extracts all hardcoded inline colors (slider fills, handles, viz strokes, panel shadows, dividers, toggles) into CSS custom properties on `.dialkit-root`
- Adds a full `[data-theme="light"]` override block with inverted palette: light glass background, dark text, softer shadows
- `'system'` mode listens to `prefers-color-scheme` and updates live without page reload
- When `theme` is omitted, existing dark appearance is unchanged (no breaking change)

## Test plan
- [ ] Verify dark mode looks identical to before (no `theme` prop)
- [ ] Pass `theme="light"` and confirm all controls render correctly on light background
- [ ] Pass `theme="system"`, toggle OS appearance, confirm panel switches live
- [ ] Check Svelte and Solid builds compile cleanly
- [ ] Confirm no merge conflicts with `feat/keyboard-shortcuts` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)