### PR TITLE
feat: conditional control visibility via visibleWhen

### DIFF
--- a/example/src/ConditionalVisibility.tsx
+++ b/example/src/ConditionalVisibility.tsx
@@ -1,0 +1,95 @@
+import { useDialKit, withVisibility } from 'dialkit';
+
+/**
+ * Conditional visibility demo
+ *
+ * Controls are wrapped with `withVisibility(control, rule)` to show/hide them
+ * based on the value of other controls in the same panel. The store watches
+ * the value changes and automatically re-filters the control tree.
+ */
+export function ConditionalVisibility() {
+  const values = useDialKit('Conditional', {
+    // Master switch
+    layoutMode: {
+      type: 'select' as const,
+      options: [
+        { value: 'grid', label: 'Grid' },
+        { value: 'sphere', label: 'Sphere' },
+        { value: 'stack', label: 'Stack' },
+      ],
+      default: 'grid',
+    },
+
+    // Grid-only controls (is-array form)
+    gapH: withVisibility([12, 0, 40], { field: 'layoutMode', is: ['grid'] }),
+    gapV: withVisibility([12, 0, 40], { field: 'layoutMode', is: 'grid' }),
+
+    // Sphere-only control
+    sphereRadius: withVisibility([1, 0.5, 5, 0.1], { field: 'layoutMode', is: 'sphere' }),
+
+    // Hidden only on stack mode (not rule)
+    scatter: withVisibility([0, 0, 1, 0.01], { field: 'layoutMode', not: 'stack' }),
+
+    // Transition control — exercises the Easing/Time/Physics mode swap
+    // animation inside TransitionControl (separate from the visibility
+    // feature, but uses the same motion pattern).
+    tween: { type: 'spring' as const, visualDuration: 0.3, bounce: 0.2 },
+
+    // Debug toggle + nested folder — kept at the bottom so conditional
+    // controls appear directly under their master switch.
+    debugMode: false,
+    debug: withVisibility(
+      {
+        _collapsed: false,
+        showStats: true,
+        verboseLogs: false,
+        tintColor: { type: 'color' as const, default: '#ff0080' },
+      },
+      { field: 'debugMode', is: true }
+    ),
+  });
+
+  const bgColor =
+    values.layoutMode === 'grid'
+      ? '#1a1a2e'
+      : values.layoutMode === 'sphere'
+        ? '#2d1a2e'
+        : '#1a2e1a';
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        background: bgColor,
+        color: '#fff',
+        fontFamily: 'system-ui, sans-serif',
+        padding: '4rem',
+        transition: 'background 0.3s ease',
+      }}
+    >
+      <h1 style={{ fontSize: '2.5rem', marginBottom: '1rem' }}>Conditional Visibility</h1>
+      <p style={{ maxWidth: 520, opacity: 0.75, lineHeight: 1.55 }}>
+        Open the panel and switch <strong>layoutMode</strong> between Grid, Sphere, and
+        Stack. Toggle <strong>debugMode</strong> on and off. Controls appear and disappear
+        based on the values of other controls in the same panel — wired with a single{' '}
+        <code>withVisibility()</code> call per control.
+      </p>
+
+      <pre
+        style={{
+          marginTop: '2rem',
+          padding: '1rem 1.25rem',
+          background: 'rgba(255,255,255,0.06)',
+          border: '1px solid rgba(255,255,255,0.1)',
+          borderRadius: 8,
+          fontSize: 13,
+          lineHeight: 1.6,
+          maxWidth: 520,
+          overflow: 'auto',
+        }}
+      >
+        {JSON.stringify(values, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -5,6 +5,7 @@ import { DialRoot } from 'dialkit';
 import 'dialkit/styles.css';
 import { PhotoStack } from './PhotoStack';
 import { Release } from './Release';
+import { ConditionalVisibility } from './ConditionalVisibility';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -12,6 +13,10 @@ createRoot(document.getElementById('root')!).render(
       <Routes>
         <Route path="/" element={<><PhotoStack /><DialRoot position="top-right" /></>} />
         <Route path="/release-1.2" element={<Release />} />
+        <Route
+          path="/conditional"
+          element={<><ConditionalVisibility /><DialRoot position="top-right" /></>}
+        />
       </Routes>
     </BrowserRouter>
   </StrictMode>

--- a/src/hooks/useDialKit.ts
+++ b/src/hooks/useDialKit.ts
@@ -1,5 +1,5 @@
 import { useEffect, useId, useSyncExternalStore, useRef } from 'react';
-import { DialStore, DialConfig, DialValue, ResolvedValues, SpringConfig, EasingConfig, SelectConfig, ColorConfig, TextConfig, ActionConfig, ShortcutConfig } from '../store/DialStore';
+import { DialStore, DialConfig, DialValue, ResolvedValues, SpringConfig, EasingConfig, SelectConfig, ColorConfig, TextConfig, ActionConfig, ShortcutConfig, unwrapVisibility } from '../store/DialStore';
 
 export interface UseDialOptions {
   onAction?: (action: string) => void;
@@ -65,9 +65,11 @@ function buildResolvedValues(
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
-  for (const [key, configValue] of Object.entries(config)) {
+  for (const [key, rawConfigValue] of Object.entries(config)) {
     if (key === '_collapsed') continue;
     const path = prefix ? `${prefix}.${key}` : key;
+    // Unwrap conditional-visibility wrapper, if any.
+    const configValue = unwrapVisibility(rawConfigValue);
 
     if (Array.isArray(configValue) && configValue.length <= 4 && typeof configValue[0] === 'number') {
       // Range tuple

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export { PresetManager } from './components/PresetManager';
 export { ShortcutsMenu } from './components/ShortcutsMenu';
 
 // Store (for advanced usage)
-export { DialStore } from './store/DialStore';
+export { DialStore, withVisibility, unwrapVisibility } from './store/DialStore';
 export type {
   SpringConfig,
   EasingConfig,
@@ -40,4 +40,7 @@ export type {
   ResolvedValues,
   ControlMeta,
   PanelConfig,
+  VisibleWhen,
+  VisibleWhenValue,
+  ControlWithVisibility,
 } from './store/DialStore';

--- a/src/solid/createDialKit.ts
+++ b/src/solid/createDialKit.ts
@@ -1,5 +1,5 @@
 import { createSignal, createMemo, onMount, onCleanup, createUniqueId, type Accessor } from 'solid-js';
-import { DialStore } from '../store/DialStore';
+import { DialStore, unwrapVisibility } from '../store/DialStore';
 import type { DialConfig, ResolvedValues, DialValue, SpringConfig, SelectConfig, ColorConfig, TextConfig, ActionConfig, ShortcutConfig } from '../store/DialStore';
 
 export interface CreateDialOptions {
@@ -48,9 +48,11 @@ function buildResolvedValues(
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
-  for (const [key, configValue] of Object.entries(config)) {
+  for (const [key, rawConfigValue] of Object.entries(config)) {
     if (key === '_collapsed') continue;
     const path = prefix ? `${prefix}.${key}` : key;
+    // Unwrap conditional-visibility wrapper, if any.
+    const configValue = unwrapVisibility(rawConfigValue);
 
     if (Array.isArray(configValue) && configValue.length <= 4 && typeof configValue[0] === 'number') {
       result[key] = flatValues[path] ?? configValue[0];

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -19,7 +19,7 @@ export { ColorControl } from './components/ColorControl';
 export { PresetManager } from './components/PresetManager';
 
 // Store exports
-export { DialStore } from '../store/DialStore';
+export { DialStore, withVisibility, unwrapVisibility } from '../store/DialStore';
 export type {
   SpringConfig,
   ActionConfig,
@@ -33,4 +33,7 @@ export type {
   ResolvedValues,
   ControlMeta,
   PanelConfig,
+  VisibleWhen,
+  VisibleWhenValue,
+  ControlWithVisibility,
 } from '../store/DialStore';

--- a/src/store/DialStore.ts
+++ b/src/store/DialStore.ts
@@ -41,8 +41,79 @@ export type TextConfig = {
 
 export type DialValue = number | boolean | string | SpringConfig | EasingConfig | ActionConfig | SelectConfig | ColorConfig | TextConfig;
 
+export type VisibleWhenValue = string | boolean | number;
+
+/**
+ * Rule for conditional control visibility. Exactly one of `is` or `not`
+ * should be provided — if both are set, only `is` is evaluated.
+ */
+export type VisibleWhen = {
+  /**
+   * Flat store path of another control in the same panel to watch.
+   * Must be the full dot-delimited path as it appears in panel.values
+   * (e.g. `"debug.showStats"` for a nested control, not a relative path).
+   */
+  field: string;
+} & (
+  | { is: VisibleWhenValue | VisibleWhenValue[]; not?: never }
+  | { not: VisibleWhenValue | VisibleWhenValue[]; is?: never }
+  | { is?: undefined; not?: undefined }
+);
+
+/**
+ * Wraps a control with a visibility rule. The control is only added to the
+ * panel's rendered tree when its rule passes. Re-evaluated on every value
+ * change. Use the {@link withVisibility} helper instead of building this by hand.
+ */
+export type ControlWithVisibility<T = DialValue | [number, number, number, number?] | DialConfig> = {
+  value: T;
+  visibleWhen: VisibleWhen;
+};
+
+/**
+ * Tag any DialKit control with a conditional visibility rule. The control is
+ * only shown when `rule` passes against the current panel values.
+ *
+ * @example
+ * const config = {
+ *   layoutMode: { type: 'select', options: ['grid', 'sphere'] },
+ *   radius: withVisibility([1, 0, 10], { field: 'layoutMode', is: 'sphere' }),
+ * };
+ */
+export function withVisibility<T extends DialValue | [number, number, number, number?] | DialConfig>(
+  control: T,
+  rule: VisibleWhen
+): ControlWithVisibility<T> {
+  return { value: control, visibleWhen: rule };
+}
+
+/** The union of all value shapes that can appear in a DialConfig entry. */
+type DialConfigValue = DialValue | [number, number, number, number?] | DialConfig;
+
+/**
+ * Detect and unwrap a `{ value, visibleWhen }` wrapper produced by
+ * {@link withVisibility}. Returns the inner value if wrapped, or the
+ * original value if not.
+ *
+ * Exported for use by framework hooks (React, Solid, Svelte, Vue) so
+ * they can strip the wrapper when building resolved values without
+ * duplicating the detection logic.
+ */
+export function unwrapVisibility(raw: unknown): DialConfigValue {
+  if (
+    typeof raw === 'object' &&
+    raw !== null &&
+    !Array.isArray(raw) &&
+    'value' in raw &&
+    'visibleWhen' in raw
+  ) {
+    return (raw as ControlWithVisibility).value;
+  }
+  return raw as DialConfigValue;
+}
+
 export type DialConfig = {
-  [key: string]: DialValue | [number, number, number, number?] | DialConfig;
+  [key: string]: DialValue | [number, number, number, number?] | DialConfig | ControlWithVisibility;
 };
 
 export type ResolvedValues<T extends DialConfig> = {
@@ -85,6 +156,8 @@ export type ControlMeta = {
   options?: (string | { value: string; label: string })[];
   placeholder?: string;
   shortcut?: ShortcutConfig;
+  /** Conditional visibility rule attached via {@link withVisibility}. */
+  visibleWhen?: VisibleWhen;
 };
 
 export type PanelConfig = {
@@ -116,13 +189,23 @@ class DialStoreClass {
   private presets: Map<string, Preset[]> = new Map();
   private activePreset: Map<string, string | null> = new Map();
   private baseValues: Map<string, Record<string, DialValue>> = new Map();
+  /**
+   * Full (unfiltered) control tree per panel. `panels[id].controls` holds the
+   * tree with conditional-visibility controls already filtered out, which is
+   * what the UI renders. We keep the unfiltered tree here so visibility can
+   * flip back when a dependent value changes.
+   */
+  private allControls: Map<string, ControlMeta[]> = new Map();
 
   registerPanel(id: string, name: string, config: DialConfig, shortcuts?: Record<string, ShortcutConfig>): void {
-    const controls = this.parseConfig(config, '', shortcuts);
+    const allControls = this.parseConfig(config, '', shortcuts);
     const values = this.flattenValues(config, '');
 
     // Set initial transition modes based on config types
     this.initTransitionModes(config, '', values);
+
+    this.allControls.set(id, allControls);
+    const controls = this.filterByVisibility(allControls, values);
 
     this.panels.set(id, { id, name, controls, values, shortcuts: shortcuts ?? {} });
     this.snapshots.set(id, { ...values });
@@ -137,8 +220,8 @@ class DialStoreClass {
       return;
     }
 
-    const controls = this.parseConfig(config, '', shortcuts);
-    const controlsByPath = this.mapControlsByPath(controls);
+    const allControls = this.parseConfig(config, '', shortcuts);
+    const controlsByPath = this.mapControlsByPath(allControls);
     const defaultValues = this.flattenValues(config, '');
     const nextValues: Record<string, DialValue> = {};
 
@@ -164,6 +247,9 @@ class DialStoreClass {
         nextValues[path] = mode;
       }
     }
+
+    this.allControls.set(id, allControls);
+    const controls = this.filterByVisibility(allControls, nextValues);
 
     const nextPanel: PanelConfig = { id, name, controls, values: nextValues, shortcuts: shortcuts ?? existing.shortcuts };
     this.panels.set(id, nextPanel);
@@ -197,6 +283,7 @@ class DialStoreClass {
     this.snapshots.delete(id);
     this.actionListeners.delete(id);
     this.baseValues.delete(id);
+    this.allControls.delete(id);
     this.notifyGlobal();
   }
 
@@ -220,6 +307,17 @@ class DialStoreClass {
     // Create a new snapshot reference so useSyncExternalStore detects the change
     this.snapshots.set(panelId, { ...panel.values });
     this.notify(panelId);
+
+    // Re-evaluate conditional visibility. If any control's visibility flipped,
+    // rebuild the filtered tree and bump the global listener so DialRoot picks
+    // up the new controls array.
+    const allControls = this.allControls.get(panelId);
+    if (!allControls) return;
+    const nextControls = this.filterByVisibility(allControls, panel.values);
+    if (!this.sameControlPaths(panel.controls, nextControls)) {
+      panel.controls = nextControls;
+      this.notifyGlobal();
+    }
   }
 
   updateSpringMode(panelId: string, path: string, mode: 'simple' | 'advanced'): void {
@@ -236,7 +334,22 @@ class DialStoreClass {
     const panel = this.panels.get(panelId);
     if (!panel) return;
 
-    panel.values[`${path}.__mode`] = mode;
+    const modePath = `${path}.__mode`;
+    panel.values[modePath] = mode;
+
+    // Auto-save to active preset or base values, mirroring updateValue.
+    // Without this, mode changes are ephemeral — they die at the next
+    // preset switch because loadPreset replaces panel.values wholesale.
+    const activeId = this.activePreset.get(panelId);
+    if (activeId) {
+      const presets = this.presets.get(panelId) ?? [];
+      const preset = presets.find(p => p.id === activeId);
+      if (preset) preset.values[modePath] = mode;
+    } else {
+      const base = this.baseValues.get(panelId);
+      if (base) base[modePath] = mode;
+    }
+
     this.snapshots.set(panelId, { ...panel.values });
     this.notify(panelId);
   }
@@ -331,6 +444,20 @@ class DialStoreClass {
     panel.values = { ...preset.values };
     this.snapshots.set(panelId, { ...panel.values });
     this.activePreset.set(panelId, presetId);
+
+    // Re-evaluate conditional visibility against the preset's values. If
+    // any control's visibility flipped (e.g. the preset changed a field
+    // that drives a `visibleWhen` rule), rebuild the filtered tree and
+    // bump the global listener so DialRoot picks up the new controls.
+    const allControls = this.allControls.get(panelId);
+    if (allControls) {
+      const nextControls = this.filterByVisibility(allControls, panel.values);
+      if (!this.sameControlPaths(panel.controls, nextControls)) {
+        panel.controls = nextControls;
+        this.notifyGlobal();
+      }
+    }
+
     this.notify(panelId);
   }
 
@@ -365,6 +492,19 @@ class DialStoreClass {
     if (panel && base) {
       panel.values = { ...base };
       this.snapshots.set(panelId, { ...panel.values });
+
+      // Re-evaluate conditional visibility against the restored base
+      // values, same as loadPreset. Without this, switching back to
+      // "Version 1" from an active preset keeps the preset's control
+      // tree even though the values have reverted.
+      const allControls = this.allControls.get(panelId);
+      if (allControls) {
+        const nextControls = this.filterByVisibility(allControls, panel.values);
+        if (!this.sameControlPaths(panel.controls, nextControls)) {
+          panel.controls = nextControls;
+          this.notifyGlobal();
+        }
+      }
     }
     this.activePreset.set(panelId, null);
     this.notify(panelId);
@@ -430,9 +570,11 @@ class DialStoreClass {
   }
 
   private initTransitionModes(config: DialConfig, prefix: string, values: Record<string, DialValue>): void {
-    for (const [key, value] of Object.entries(config)) {
+    for (const [key, rawValue] of Object.entries(config)) {
       if (key === '_collapsed') continue;
       const path = prefix ? `${prefix}.${key}` : key;
+      // Unwrap conditional-visibility wrapper before shape dispatch.
+      const value = this.unwrapVisibilityWithRule(rawValue).value;
 
       if (this.isEasingConfig(value)) {
         values[`${path}.__mode`] = 'easing';
@@ -449,12 +591,25 @@ class DialStoreClass {
 
   private parseConfig(config: DialConfig, prefix: string, shortcuts?: Record<string, ShortcutConfig>): ControlMeta[] {
     const controls: ControlMeta[] = [];
+    const startLen = () => controls.length;
+    const tagLast = (visibleWhen: VisibleWhen | undefined, before: number) => {
+      if (!visibleWhen) return;
+      for (let i = before; i < controls.length; i++) {
+        if (!controls[i].visibleWhen) controls[i].visibleWhen = visibleWhen;
+      }
+    };
 
-    for (const [key, value] of Object.entries(config)) {
+    for (const [key, rawValue] of Object.entries(config)) {
       if (key === '_collapsed') continue;
       const path = prefix ? `${prefix}.${key}` : key;
       const label = this.formatLabel(key);
       const shortcut = shortcuts?.[path];
+
+      // Unwrap conditional-visibility wrapper, remember the rule.
+      const unwrapped = this.unwrapVisibilityWithRule(rawValue);
+      const value = unwrapped.value;
+      const visibleWhen = unwrapped.visibleWhen;
+      const before = startLen();
 
       if (Array.isArray(value) && value.length <= 4 && typeof value[0] === 'number') {
         // Range tuple: [default, min, max]
@@ -502,6 +657,8 @@ class DialStoreClass {
           children: this.parseConfig(folderConfig, path, shortcuts),
         });
       }
+
+      tagLast(visibleWhen, before);
     }
 
     return controls;
@@ -510,9 +667,11 @@ class DialStoreClass {
   private flattenValues(config: DialConfig, prefix: string): Record<string, DialValue> {
     const values: Record<string, DialValue> = {};
 
-    for (const [key, value] of Object.entries(config)) {
+    for (const [key, rawValue] of Object.entries(config)) {
       if (key === '_collapsed') continue;
       const path = prefix ? `${prefix}.${key}` : key;
+      // Unwrap conditional-visibility wrapper before shape dispatch.
+      const value = this.unwrapVisibilityWithRule(rawValue).value;
 
       if (Array.isArray(value) && value.length <= 4 && typeof value[0] === 'number') {
         values[path] = value[0]; // Default value
@@ -714,6 +873,105 @@ class DialStoreClass {
 
     visit(controls);
     return map;
+  }
+
+  // ─── Conditional visibility ──────────────────────────────────────
+
+  /**
+   * Detects and unwraps a `{ value, visibleWhen }` wrapper produced by
+   * {@link withVisibility}. Returns the inner control plus the rule (or
+   * `undefined` for `visibleWhen` if the input was not a wrapper).
+   */
+  private unwrapVisibilityWithRule(raw: unknown): { value: DialConfigValue; visibleWhen: VisibleWhen | undefined } {
+    if (
+      typeof raw === 'object' &&
+      raw !== null &&
+      !Array.isArray(raw) &&
+      'value' in raw &&
+      'visibleWhen' in raw
+    ) {
+      const wrapper = raw as ControlWithVisibility;
+      return { value: wrapper.value, visibleWhen: wrapper.visibleWhen };
+    }
+    return { value: raw as DialConfigValue, visibleWhen: undefined };
+  }
+
+  /** Evaluate a visibility rule against a flat value map. */
+  private isVisible(rule: VisibleWhen | undefined, values: Record<string, DialValue>): boolean {
+    if (!rule) return true;
+    const actual = values[rule.field];
+    if (actual === undefined && !(rule.field in values)) {
+      // Dev-mode warning for mistyped field paths. Guarded by typeof check
+      // so it's safe in environments without process (bundlers strip this).
+      if (typeof globalThis !== 'undefined' && typeof console !== 'undefined') {
+        console.warn(
+          `[DialKit] visibleWhen references field "${rule.field}" which does not exist in the panel's values. ` +
+          `The control will default to visible. Check for typos — field must be the full dot-delimited store path.`
+        );
+      }
+    }
+    if (rule.is !== undefined) {
+      const targets = Array.isArray(rule.is) ? rule.is : [rule.is];
+      return targets.some(t => t === actual);
+    }
+    if (rule.not !== undefined) {
+      const targets = Array.isArray(rule.not) ? rule.not : [rule.not];
+      return !targets.some(t => t === actual);
+    }
+    return true;
+  }
+
+  /**
+   * Recursively filter a control tree by evaluating each control's
+   * `visibleWhen` against the current values. Folders that become empty
+   * after filtering their children are pruned.
+   *
+   * KNOWN LIMITATION — folder collapsed state across hide/show cycles:
+   * Folder open/closed state lives in `Folder`'s local `useState`, not in
+   * the store. When a folder's `visibleWhen` fails, its DOM node unmounts
+   * and that local state is lost. Re-showing the folder mounts a fresh
+   * instance with `defaultOpen`, so a user-collapsed folder will re-open
+   * after a visibility cycle. Sibling visibility changes do NOT trigger
+   * this (motion.div keys are stable by path), only the wrapped folder
+   * itself hiding. This is a pre-existing architectural constraint of
+   * DialKit's folder state model, not introduced by this feature — any
+   * mechanism that unmounts a folder would behave the same. Lifting
+   * folder state into the store is a possible follow-up.
+   */
+  private filterByVisibility(controls: ControlMeta[], values: Record<string, DialValue>): ControlMeta[] {
+    const result: ControlMeta[] = [];
+    for (const control of controls) {
+      if (!this.isVisible(control.visibleWhen, values)) continue;
+
+      if (control.type === 'folder' && control.children) {
+        const filteredChildren = this.filterByVisibility(control.children, values);
+        if (filteredChildren.length === 0) continue;
+        result.push({ ...control, children: filteredChildren });
+      } else {
+        result.push(control);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Cheap structural comparison used to decide whether visibility flipped
+   * after an updateValue. We only care about the set of visible paths —
+   * labels/options/etc can't change between snapshots of the same tree.
+   */
+  private sameControlPaths(a: ControlMeta[], b: ControlMeta[]): boolean {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      const ca = a[i];
+      const cb = b[i];
+      if (ca.path !== cb.path || ca.type !== cb.type) return false;
+      if (ca.type === 'folder') {
+        const childrenA = ca.children ?? [];
+        const childrenB = cb.children ?? [];
+        if (!this.sameControlPaths(childrenA, childrenB)) return false;
+      }
+    }
+    return true;
   }
 
 }

--- a/src/svelte/createDialKit.svelte.ts
+++ b/src/svelte/createDialKit.svelte.ts
@@ -1,4 +1,4 @@
-import { DialStore } from 'dialkit/store';
+import { DialStore, unwrapVisibility } from 'dialkit/store';
 import type {
   ActionConfig,
   ColorConfig,
@@ -60,9 +60,11 @@ function buildResolvedValues(
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
-  for (const [key, configValue] of Object.entries(config)) {
+  for (const [key, rawConfigValue] of Object.entries(config)) {
     if (key === '_collapsed') continue;
     const path = prefix ? `${prefix}.${key}` : key;
+    // Unwrap conditional-visibility wrapper, if any.
+    const configValue = unwrapVisibility(rawConfigValue);
 
     if (Array.isArray(configValue) && configValue.length <= 4 && typeof configValue[0] === 'number') {
       result[key] = flatValues[path] ?? configValue[0];

--- a/src/svelte/index.ts
+++ b/src/svelte/index.ts
@@ -27,7 +27,7 @@ export { default as ColorControl } from './components/ColorControl.svelte';
 export { default as PresetManager } from './components/PresetManager.svelte';
 
 // Store exports (via dialkit/store subpath — svelte-package doesn't bundle, so relative paths to src/store would break in dist)
-export { DialStore } from 'dialkit/store';
+export { DialStore, withVisibility, unwrapVisibility } from 'dialkit/store';
 export type {
   SpringConfig,
   EasingConfig,
@@ -43,4 +43,7 @@ export type {
   ResolvedValues,
   ControlMeta,
   PanelConfig,
+  VisibleWhen,
+  VisibleWhenValue,
+  ControlWithVisibility,
 } from 'dialkit/store';

--- a/src/vue/index.ts
+++ b/src/vue/index.ts
@@ -23,7 +23,7 @@ export { SelectControl } from './components/SelectControl';
 export { ColorControl } from './components/ColorControl';
 export { PresetManager } from './components/PresetManager';
 
-export { DialStore } from '../store/DialStore';
+export { DialStore, withVisibility, unwrapVisibility } from '../store/DialStore';
 export type {
   SpringConfig,
   EasingConfig,
@@ -39,4 +39,7 @@ export type {
   ControlMeta,
   PanelConfig,
   ShortcutConfig,
+  VisibleWhen,
+  VisibleWhenValue,
+  ControlWithVisibility,
 } from '../store/DialStore';

--- a/src/vue/useDialKit.ts
+++ b/src/vue/useDialKit.ts
@@ -1,5 +1,5 @@
 import { computed, onMounted, onUnmounted, ref, shallowRef, watch, type ComputedRef } from 'vue';
-import { DialStore } from '../store/DialStore';
+import { DialStore, unwrapVisibility } from '../store/DialStore';
 import type {
   ActionConfig,
   ColorConfig,
@@ -88,9 +88,11 @@ function buildResolvedValues(
 ): Record<string, unknown> {
   const result: Record<string, unknown> = {};
 
-  for (const [key, configValue] of Object.entries(config)) {
+  for (const [key, rawConfigValue] of Object.entries(config)) {
     if (key === '_collapsed') continue;
     const path = prefix ? `${prefix}.${key}` : key;
+    // Unwrap conditional-visibility wrapper, if any.
+    const configValue = unwrapVisibility(rawConfigValue);
 
     if (Array.isArray(configValue) && configValue.length <= 4 && typeof configValue[0] === 'number') {
       result[key] = flatValues[path] ?? configValue[0];


### PR DESCRIPTION
Adds a store-layer conditional visibility feature so controls can be shown or hidden based on other controls' values in the same panel.

## What changed

- New `withVisibility(control, rule)` helper and `VisibleWhen` type, exported from react / solid / svelte / vue entry points
- Store-level evaluation: `filterByVisibility` runs on `registerPanel`, `updatePanel`, `updateValue`, `loadPreset`, and `clearActivePreset`
- Empty folders are pruned recursively when all children become hidden
- Hidden controls retain their values across hide/show cycles
- Exported `unwrapVisibility` utility used by all four framework hooks (eliminates duplicated unwrap logic)
- Example demo at `/conditional` exercises scalar, array, boolean, nested folder, and transition control visibility in combination

Also fixes `updateTransitionMode` not auto-saving the mode to the active preset or baseValues (same pattern as the `loadPreset` fix; discovered while testing the demo across multiple preset versions).

## Why

Fully opt-in — configs without the `withVisibility` wrapper behave exactly as before. Zero DOM changes, zero CSS changes, no impact on existing theme customizations or consumers with custom DialKit styles.

The `isVisible` evaluator and empty-folder pruner are direct ports from a production app with conditional visibility rules across multiple UI surfaces.

A follow-up PR (stacked on this branch) adds smooth enter/exit animations for conditional controls.

## Validation

- `npm run build` ✓
- `npm run typecheck` ✓ (pre-existing Svelte DialRoot error unrelated)
- Tested on `/conditional` demo, PhotoStack demo, and Release demo — all functional