### PR TITLE
Add DialScope to route useDialKit panels to a specific DialRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,52 @@ In inline mode, the `position` prop is ignored and the collapse-to-icon behavior
 
 ---
 
+## DialScope
+
+By default, every `useDialKit` call registers into a single global scope and every `DialRoot` shows all of them. `DialScope` lets you fence a `DialRoot` to only the `useDialKit` calls inside its subtree — useful for rendering an inline panel next to each component on a docs or playground page.
+
+```jsx
+import { DialScope, DialRoot, useDialKit } from 'dialkit';
+
+function CardDemo() {
+  const { radius } = useDialKit('Card', { radius: [12, 0, 48] });
+  return <div style={{ borderRadius: radius }} />;
+}
+
+function ButtonDemo() {
+  const { padding } = useDialKit('Button', { padding: [12, 4, 32] });
+  return <button style={{ padding }}>Click</button>;
+}
+
+export default function Page() {
+  return (
+    <>
+      <DialScope>
+        <CardDemo />
+        <DialRoot mode="inline" /> {/* shows only "Card" */}
+      </DialScope>
+
+      <DialScope>
+        <ButtonDemo />
+        <DialRoot mode="inline" /> {/* shows only "Button" */}
+      </DialScope>
+    </>
+  );
+}
+```
+
+Each `DialScope` generates a stable id automatically. Pass an explicit `id` when the hook and the root can't share a subtree:
+
+```jsx
+<DialScope id="card"><CardDemo /></DialScope>
+{/* …elsewhere… */}
+<DialScope id="card"><DialRoot mode="inline" /></DialScope>
+```
+
+`DialScope` is React-only for now.
+
+---
+
 ## Panel Toolbar
 
 When the panel is open, the toolbar provides:

--- a/src/components/DialRoot.tsx
+++ b/src/components/DialRoot.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { DialStore, PanelConfig } from '../store/DialStore';
+import { useDialScope } from '../hooks/DialScope';
 import { Panel } from './Panel';
 import { ShortcutListener } from './ShortcutListener';
 
@@ -26,9 +27,11 @@ interface DialRootProps {
 
 export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'popover', theme = 'system', productionEnabled = isDevDefault }: DialRootProps) {
   if (!productionEnabled) return null;
-  const [panels, setPanels] = useState<PanelConfig[]>([]);
+  const scopeId = useDialScope();
+  const [allPanels, setAllPanels] = useState<PanelConfig[]>([]);
   const [mounted, setMounted] = useState(false);
   const inline = mode === 'inline';
+  const panels = allPanels.filter((p) => p.scopeId === scopeId);
 
   // Drag state
   const panelRef = useRef<HTMLDivElement>(null);
@@ -42,10 +45,10 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
   // Subscribe to global panel changes
   useEffect(() => {
     setMounted(true);
-    setPanels(DialStore.getPanels());
+    setAllPanels(DialStore.getPanels());
 
     const unsubscribe = DialStore.subscribeGlobal(() => {
-      setPanels(DialStore.getPanels());
+      setAllPanels(DialStore.getPanels());
     });
 
     return unsubscribe;

--- a/src/hooks/DialScope.tsx
+++ b/src/hooks/DialScope.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useId, ReactNode } from 'react';
+import { DEFAULT_DIAL_SCOPE } from '../store/DialStore';
+
+export const DialScopeContext = createContext<string>(DEFAULT_DIAL_SCOPE);
+
+export function useDialScope(): string {
+  return useContext(DialScopeContext);
+}
+
+interface DialScopeProps {
+  /** Optional explicit scope id. Defaults to a stable auto-generated id. */
+  id?: string;
+  children: ReactNode;
+}
+
+/**
+ * Scopes useDialKit registrations to the nearest DialRoot rendered within the
+ * same DialScope. Without a DialScope, all useDialKit panels share the default
+ * scope and appear in every default-scoped DialRoot.
+ */
+export function DialScope({ id, children }: DialScopeProps) {
+  const autoId = useId();
+  return (
+    <DialScopeContext.Provider value={id ?? autoId}>
+      {children}
+    </DialScopeContext.Provider>
+  );
+}

--- a/src/hooks/useDialKit.ts
+++ b/src/hooks/useDialKit.ts
@@ -1,5 +1,6 @@
 import { useEffect, useId, useSyncExternalStore, useRef } from 'react';
 import { DialStore, DialConfig, DialValue, ResolvedValues, SpringConfig, EasingConfig, SelectConfig, ColorConfig, TextConfig, ActionConfig, ShortcutConfig } from '../store/DialStore';
+import { useDialScope } from './DialScope';
 
 export interface UseDialOptions {
   onAction?: (action: string) => void;
@@ -12,6 +13,7 @@ export function useDialKit<T extends DialConfig>(
   options?: UseDialOptions
 ): ResolvedValues<T> {
   const instanceId = useId();
+  const scopeId = useDialScope();
   const panelId = `${name}-${instanceId}`;
   const configRef = useRef(config);
   const serializedConfig = JSON.stringify(config);
@@ -24,9 +26,9 @@ export function useDialKit<T extends DialConfig>(
 
   // Register panel on mount
   useEffect(() => {
-    DialStore.registerPanel(panelId, name, configRef.current, shortcutsRef.current);
+    DialStore.registerPanel(panelId, name, configRef.current, shortcutsRef.current, scopeId);
     return () => DialStore.unregisterPanel(panelId);
-  }, [panelId, name]);
+  }, [panelId, name, scopeId]);
 
   // Update panel when config structure or shortcuts change
   const mountedRef = useRef(false);
@@ -35,9 +37,9 @@ export function useDialKit<T extends DialConfig>(
       mountedRef.current = true;
       return;
     }
-    DialStore.updatePanel(panelId, name, configRef.current, shortcutsRef.current);
+    DialStore.updatePanel(panelId, name, configRef.current, shortcutsRef.current, scopeId);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [panelId, name, serializedConfig, serializedShortcuts]);
+  }, [panelId, name, serializedConfig, serializedShortcuts, scopeId]);
 
   // Subscribe to action events
   useEffect(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@
 export { useDialKit } from './hooks/useDialKit';
 export type { UseDialOptions } from './hooks/useDialKit';
 
+// Scope provider for routing useDialKit panels to a specific DialRoot
+export { DialScope, DialScopeContext, useDialScope } from './hooks/DialScope';
+
 // Root component (user mounts once)
 export { DialRoot } from './components/DialRoot';
 export type { DialPosition, DialMode, DialTheme } from './components/DialRoot';

--- a/src/store/DialStore.ts
+++ b/src/store/DialStore.ts
@@ -1,5 +1,7 @@
 // Lightweight state store with subscriptions for dialkit
 
+export const DEFAULT_DIAL_SCOPE = '__dialkit_default__';
+
 export type SpringConfig = {
   type: 'spring';
   stiffness?: number;
@@ -90,6 +92,7 @@ export type ControlMeta = {
 export type PanelConfig = {
   id: string;
   name: string;
+  scopeId: string;
   controls: ControlMeta[];
   values: Record<string, DialValue>;
   shortcuts: Record<string, ShortcutConfig>;
@@ -117,23 +120,23 @@ class DialStoreClass {
   private activePreset: Map<string, string | null> = new Map();
   private baseValues: Map<string, Record<string, DialValue>> = new Map();
 
-  registerPanel(id: string, name: string, config: DialConfig, shortcuts?: Record<string, ShortcutConfig>): void {
+  registerPanel(id: string, name: string, config: DialConfig, shortcuts?: Record<string, ShortcutConfig>, scopeId: string = DEFAULT_DIAL_SCOPE): void {
     const controls = this.parseConfig(config, '', shortcuts);
     const values = this.flattenValues(config, '');
 
     // Set initial transition modes based on config types
     this.initTransitionModes(config, '', values);
 
-    this.panels.set(id, { id, name, controls, values, shortcuts: shortcuts ?? {} });
+    this.panels.set(id, { id, name, scopeId, controls, values, shortcuts: shortcuts ?? {} });
     this.snapshots.set(id, { ...values });
     this.baseValues.set(id, { ...values });
     this.notifyGlobal();
   }
 
-  updatePanel(id: string, name: string, config: DialConfig, shortcuts?: Record<string, ShortcutConfig>): void {
+  updatePanel(id: string, name: string, config: DialConfig, shortcuts?: Record<string, ShortcutConfig>, scopeId?: string): void {
     const existing = this.panels.get(id);
     if (!existing) {
-      this.registerPanel(id, name, config, shortcuts);
+      this.registerPanel(id, name, config, shortcuts, scopeId);
       return;
     }
 
@@ -165,7 +168,7 @@ class DialStoreClass {
       }
     }
 
-    const nextPanel: PanelConfig = { id, name, controls, values: nextValues, shortcuts: shortcuts ?? existing.shortcuts };
+    const nextPanel: PanelConfig = { id, name, scopeId: scopeId ?? existing.scopeId, controls, values: nextValues, shortcuts: shortcuts ?? existing.shortcuts };
     this.panels.set(id, nextPanel);
     this.snapshots.set(id, { ...nextValues });
 


### PR DESCRIPTION
NOTE: claude-authored; I verified the fix myself & code-reviewed by hand

## What

Adds a `<DialScope>` provider so a `DialRoot` only renders the `useDialKit` panels registered inside its subtree, instead of every panel in the app.

## Why

I want to render an inline `DialRoot` next to each component on a playground page (the panel for component A next to component A, the panel for component B further down the page next to component B). Today every `DialRoot` shows every registered panel.

## How

- `useDialKit` reads a scope id from the nearest `DialScope` (default scope when there isn't one) and stores it on the panel in `DialStore`.
- `DialRoot` reads the same scope id and filters panels to its scope.
- With no `DialScope` anywhere, both default to the same shared scope, so existing single-root usage is unchanged.
- `DialScope` accepts an optional `id` for cases where the hook and the root can't share a subtree.

README has a usage example. React-only for now.

One known caveat I left alone: `ShortcutListener` attaches window-level listeners per `DialRoot`, so two scoped roots that both define the *same* shortcut key would each fire it. That's pre-existing behaviour for multiple roots; happy to follow up with scope-aware shortcut resolution if there's interest.

Closes #33.