### PR TITLE
Fix keyboard accessibility & focus styles across all frameworks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "dialkit",
       "version": "1.3.0",
       "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
       "devDependencies": {
         "@sveltejs/package": "^2.4.0",
         "@types/react": "^18.2.0",
@@ -928,6 +931,31 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",

--- a/package.json
+++ b/package.json
@@ -122,5 +122,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/joshpuckett/dialkit"
+  },
+  "dependencies": {
+    "@floating-ui/dom": "^1.7.6"
   }
 }

--- a/src/components/DialRoot.tsx
+++ b/src/components/DialRoot.tsx
@@ -109,7 +109,13 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
     dragStartRef.current = getPanelDragStart(e.clientX, e.clientY, panel);
     didDragRef.current = false;
     draggingRef.current = true;
-    handle.setPointerCapture(e.pointerId);
+    // The pointer may already be gone (fast release, synthetic events) — capture
+    // is best-effort and must not throw.
+    try {
+      handle.setPointerCapture(e.pointerId);
+    } catch {
+      /* no active pointer to capture */
+    }
   }, []);
 
   const handlePointerMove = useCallback((e: React.PointerEvent) => {
@@ -127,8 +133,12 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
     dragStartRef.current = null;
     const dragTarget = dragTargetRef.current;
 
-    if (dragTarget?.hasPointerCapture(e.pointerId)) {
-      dragTarget.releasePointerCapture(e.pointerId);
+    try {
+      if (dragTarget?.hasPointerCapture(e.pointerId)) {
+        dragTarget.releasePointerCapture(e.pointerId);
+      }
+    } catch {
+      /* pointer already released */
     }
 
     // If we actually dragged, prevent the click from opening the panel

--- a/src/components/Folder.tsx
+++ b/src/components/Folder.tsx
@@ -53,13 +53,32 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, in
     onOpenChange?.(next);
   };
 
+  const handleToggleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleToggle();
+    }
+  };
+
+  // The header toggles the folder. For a root panel it's only interactive
+  // while open (collapsing it); the collapsed circle handles re-opening.
+  const headerInteractive = isRoot ? isOpen && !inline : true;
+
   const folderContent = (
     <div
       ref={isRoot ? contentRef : undefined}
       className={`dialkit-folder ${isRoot ? 'dialkit-folder-root' : ''}`}
       data-open={String(isOpen)}
     >
-      <div className={`dialkit-folder-header ${isRoot ? 'dialkit-panel-header' : ''}`} onClick={handleToggle}>
+      <div
+        className={`dialkit-folder-header ${isRoot ? 'dialkit-panel-header' : ''}`}
+        onClick={handleToggle}
+        role={headerInteractive ? 'button' : undefined}
+        tabIndex={headerInteractive ? 0 : undefined}
+        aria-expanded={headerInteractive ? isOpen : undefined}
+        aria-label={headerInteractive ? title : undefined}
+        onKeyDown={headerInteractive ? handleToggleKeyDown : undefined}
+      >
         <div className="dialkit-folder-header-top">
           {isRoot ? (
             isOpen && (
@@ -148,6 +167,11 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, in
         className="dialkit-panel-inner"
         style={panelStyle}
         onClick={!isOpen ? handleToggle : undefined}
+        role={!isOpen ? 'button' : undefined}
+        tabIndex={!isOpen ? 0 : undefined}
+        aria-expanded={!isOpen ? false : undefined}
+        aria-label={!isOpen ? title : undefined}
+        onKeyDown={!isOpen ? handleToggleKeyDown : undefined}
         data-collapsed={isCollapsed}
         whileTap={!isOpen ? { scale: 0.9 } : undefined}
         transition={{ type: 'spring', visualDuration: 0.15, bounce: 0.3 }}

--- a/src/components/PresetManager.tsx
+++ b/src/components/PresetManager.tsx
@@ -1,7 +1,8 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
 import { DialStore, Preset } from '../store/DialStore';
+import { useFloatingDropdown } from '../hooks/useFloatingDropdown';
 import { ICON_CHEVRON, ICON_TRASH } from '../icons';
 
 interface PresetManagerProps {
@@ -13,30 +14,112 @@ interface PresetManagerProps {
 
 export function PresetManager({ panelId, presets, activePresetId, onAdd }: PresetManagerProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState({ top: 0, left: 0, width: 0 });
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const baseId = useId();
+  const { triggerRef, floatingRef } = useFloatingDropdown<HTMLButtonElement, HTMLDivElement>(isOpen, {
+    placement: 'bottom-start',
+    matchWidth: true,
+  });
 
   const hasPresets = presets.length > 0;
   const activePreset = presets.find((p) => p.id === activePresetId);
 
-  const open = useCallback(() => {
-    if (!hasPresets) return;
-    const rect = triggerRef.current?.getBoundingClientRect();
-    if (rect) {
-      setPos({ top: rect.bottom + 4, left: rect.left, width: rect.width });
-    }
-    setIsOpen(true);
-  }, [hasPresets]);
+  // Flat selectable list: the implicit "Version 1" (no preset) plus each preset.
+  const items: { id: string | null; name: string }[] = [
+    { id: null, name: 'Version 1' },
+    ...presets.map((p) => ({ id: p.id, name: p.name })),
+  ];
+  const selectedIndex = Math.max(0, items.findIndex((it) => it.id === activePresetId));
+  const optionId = (index: number) => `${baseId}-opt-${index}`;
 
   const close = useCallback(() => setIsOpen(false), []);
 
-  const toggle = useCallback(() => {
-    if (isOpen) close();
-    else open();
-  }, [isOpen, open, close]);
+  const openMenu = useCallback((toIndex: number) => {
+    if (!hasPresets) return;
+    setActiveIndex(toIndex);
+    setIsOpen(true);
+    // macOS Safari/Firefox don't focus a <button> on click — force it so the
+    // trigger's key handler receives arrow keys.
+    triggerRef.current?.focus();
+  }, [hasPresets, triggerRef]);
 
-  // Close on any mousedown outside trigger + dropdown
+  const handleSelect = useCallback((presetId: string | null) => {
+    if (presetId) {
+      DialStore.loadPreset(panelId, presetId);
+    } else {
+      DialStore.clearActivePreset(panelId);
+    }
+    close();
+  }, [panelId, close]);
+
+  // Keep the active item scrolled into view.
+  useEffect(() => {
+    if (isOpen && activeIndex >= 0) {
+      document.getElementById(optionId(activeIndex))?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [isOpen, activeIndex]);
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMenu(selectedIndex);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        openMenu(items.length - 1);
+      }
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % items.length);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((i) => (i - 1 + items.length) % items.length);
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(items.length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (activeIndex >= 0) handleSelect(items[activeIndex].id);
+        break;
+      case 'Delete':
+      case 'Backspace': {
+        const target = items[activeIndex];
+        if (target?.id) {
+          e.preventDefault();
+          DialStore.deletePreset(panelId, target.id);
+          setActiveIndex((i) => Math.max(0, i - 1));
+        }
+        break;
+      }
+      case 'Escape':
+        e.preventDefault();
+        close();
+        break;
+      case 'Tab':
+        close();
+        break;
+    }
+  };
+
+  // Close when focus leaves the trigger.
+  const handleTriggerBlur = (e: React.FocusEvent) => {
+    const next = e.relatedTarget as Node | null;
+    if (floatingRef.current?.contains(next)) return;
+    close();
+  };
+
+  // Close on mousedown outside trigger + dropdown.
   useEffect(() => {
     if (!isOpen) return;
 
@@ -44,23 +127,14 @@ export function PresetManager({ panelId, presets, activePresetId, onAdd }: Prese
       const target = e.target as Node;
       if (
         triggerRef.current?.contains(target) ||
-        dropdownRef.current?.contains(target)
+        floatingRef.current?.contains(target)
       ) return;
       close();
     };
 
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
-  }, [isOpen, close]);
-
-  const handleSelect = (presetId: string | null) => {
-    if (presetId) {
-      DialStore.loadPreset(panelId, presetId);
-    } else {
-      DialStore.clearActivePreset(panelId);
-    }
-    close();
-  };
+  }, [isOpen, close, triggerRef, floatingRef]);
 
   const handleDelete = (e: React.MouseEvent, presetId: string) => {
     e.stopPropagation();
@@ -72,10 +146,16 @@ export function PresetManager({ panelId, presets, activePresetId, onAdd }: Prese
       <button
         ref={triggerRef}
         className="dialkit-preset-trigger"
-        onClick={toggle}
+        onClick={() => (isOpen ? close() : openMenu(selectedIndex))}
+        onKeyDown={handleTriggerKeyDown}
+        onBlur={handleTriggerBlur}
         data-open={String(isOpen)}
         data-has-preset={String(!!activePreset)}
         data-disabled={String(!hasPresets)}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? `${baseId}-listbox` : undefined}
+        aria-activedescendant={isOpen && activeIndex >= 0 ? optionId(activeIndex) : undefined}
       >
         <span className="dialkit-preset-label">
           {activePreset ? activePreset.name : 'Version 1'}
@@ -99,41 +179,45 @@ export function PresetManager({ panelId, presets, activePresetId, onAdd }: Prese
         <AnimatePresence>
           {isOpen && (
             <motion.div
-              ref={dropdownRef}
+              ref={floatingRef}
+              id={`${baseId}-listbox`}
               className="dialkit-root dialkit-preset-dropdown"
-              style={{ position: 'fixed', top: pos.top, left: pos.left, minWidth: pos.width }}
+              role="listbox"
+              style={{ position: 'fixed', top: 0, left: 0 }}
               initial={{ opacity: 0, y: 4, scale: 0.97 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
               exit={{ opacity: 0, y: 4, scale: 0.97, pointerEvents: 'none' as any }}
               transition={{ type: 'spring', visualDuration: 0.15, bounce: 0 }}
             >
-              <div
-                className="dialkit-preset-item"
-                data-active={String(!activePresetId)}
-                onClick={() => handleSelect(null)}
-              >
-                <span className="dialkit-preset-name">Version 1</span>
-              </div>
-
-              {presets.map((preset) => (
+              {items.map((item, index) => (
                 <div
-                  key={preset.id}
+                  key={item.id ?? '__none__'}
+                  id={optionId(index)}
                   className="dialkit-preset-item"
-                  data-active={String(preset.id === activePresetId)}
-                  onClick={() => handleSelect(preset.id)}
+                  role="option"
+                  aria-selected={index === selectedIndex}
+                  data-active={String(index === activeIndex)}
+                  data-selected={String(index === selectedIndex)}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  onClick={() => handleSelect(item.id)}
                 >
-                  <span className="dialkit-preset-name">{preset.name}</span>
-                  <button
-                    className="dialkit-preset-delete"
-                    onClick={(e) => handleDelete(e, preset.id)}
-                    title="Delete preset"
-                  >
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      {ICON_TRASH.map((d, i) => (
-                        <path key={i} d={d} />
-                      ))}
-                    </svg>
-                  </button>
+                  <span className="dialkit-preset-name">{item.name}</span>
+                  {item.id && (
+                    <button
+                      className="dialkit-preset-delete"
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={(e) => handleDelete(e, item.id!)}
+                      title="Delete preset"
+                      tabIndex={-1}
+                    >
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                        {ICON_TRASH.map((d, i) => (
+                          <path key={i} d={d} />
+                        ))}
+                      </svg>
+                    </button>
+                  )}
                 </div>
               ))}
             </motion.div>

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -9,14 +9,17 @@ interface SegmentedControlProps<T extends string> {
   options: SegmentedControlOption<T>[];
   value: T;
   onChange: (value: T) => void;
+  label?: string;
 }
 
 export function SegmentedControl<T extends string>({
   options,
   value,
   onChange,
+  label,
 }: SegmentedControlProps<T>) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const hasAnimated = useRef(false);
   const [pillStyle, setPillStyle] = useState<{ left: number; width: number } | null>(null);
 
@@ -39,8 +42,42 @@ export function SegmentedControl<T extends string>({
   const shouldAnimate = hasAnimated.current;
   hasAnimated.current = true;
 
+  const activeIndex = Math.max(0, options.findIndex((o) => o.value === value));
+
+  // Radiogroup arrow-key navigation: moving focus also moves selection,
+  // matching the WAI-ARIA radio pattern.
+  const handleKeyDown = (e: React.KeyboardEvent, index: number) => {
+    let nextIndex: number | null = null;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIndex = (index + 1) % options.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIndex = (index - 1 + options.length) % options.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = options.length - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    onChange(options[nextIndex].value);
+    buttonRefs.current[nextIndex]?.focus();
+  };
+
   return (
-    <div className="dialkit-segmented" ref={containerRef}>
+    <div
+      className="dialkit-segmented"
+      ref={containerRef}
+      role="radiogroup"
+      aria-label={label}
+    >
       {pillStyle && (
         <div
           className="dialkit-segmented-pill"
@@ -54,12 +91,18 @@ export function SegmentedControl<T extends string>({
         />
       )}
 
-      {options.map((option) => {
+      {options.map((option, index) => {
         const isActive = value === option.value;
         return (
           <button
             key={option.value}
+            ref={(el) => { buttonRefs.current[index] = el; }}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            tabIndex={index === activeIndex ? 0 : -1}
             onClick={() => onChange(option.value)}
+            onKeyDown={(e) => handleKeyDown(e, index)}
             className="dialkit-segmented-button"
             data-active={String(isActive)}
           >

--- a/src/components/SelectControl.tsx
+++ b/src/components/SelectControl.tsx
@@ -1,7 +1,8 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
-import { getDialKitPortalRoot, getDropdownPosition } from '../dropdown-position';
+import { getDialKitPortalRoot } from '../dropdown-position';
+import { useFloatingDropdown } from '../hooks/useFloatingDropdown';
 import { ICON_CHEVRON } from '../icons';
 
 type SelectOption = string | { value: string; label: string };
@@ -25,33 +26,98 @@ function normalizeOptions(options: SelectOption[]): { value: string; label: stri
 
 export function SelectControl({ label, value, options, onChange }: SelectControlProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
   const [portalTarget, setPortalTarget] = useState<HTMLElement | null>(null);
-  const [pos, setPos] = useState<{ top: number; left: number; width: number; above: boolean } | null>(null);
+  const { triggerRef, floatingRef } = useFloatingDropdown<HTMLButtonElement, HTMLDivElement>(isOpen, {
+    placement: 'bottom-start',
+    matchWidth: true,
+  });
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const baseId = useId();
   const normalized = normalizeOptions(options);
-  const selectedOption = normalized.find((o) => o.value === value);
+  const selectedIndex = normalized.findIndex((o) => o.value === value);
+  const selectedOption = normalized[selectedIndex];
+  const optionId = (index: number) => `${baseId}-opt-${index}`;
 
-  const updatePos = useCallback(() => {
-    const el = triggerRef.current;
-    if (!el || !portalTarget) return;
-    // Estimate dropdown height: 8px padding + 36px per option
-    const dropdownHeight = 8 + normalized.length * 36;
-    setPos(getDropdownPosition(el, portalTarget, { dropdownHeight }));
-  }, [normalized.length, portalTarget]);
-
-  // Resolve portal target (closest .dialkit-root)
+  // Resolve portal target (closest .dialkit-root) so theme vars apply.
   useEffect(() => {
     setPortalTarget(getDialKitPortalRoot(triggerRef.current) ?? document.body);
-  }, []);
+  }, [triggerRef]);
 
-  // Position dropdown when opening
+  // Focus never leaves the trigger — the active option is tracked with
+  // aria-activedescendant. This keeps arrow keys off the panel's scroll
+  // container and makes blur-to-close trivial (trigger blur = close).
   useEffect(() => {
-    if (!isOpen) return;
-    updatePos();
-  }, [isOpen, updatePos]);
+    if (isOpen && activeIndex >= 0) {
+      optionRefs.current[activeIndex]?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [isOpen, activeIndex]);
 
-  // Close on click outside
+  const openMenu = useCallback((toIndex: number) => {
+    setActiveIndex(toIndex);
+    setIsOpen(true);
+    // macOS Safari/Firefox don't focus a <button> on click, so force it —
+    // otherwise arrow keys hit the page instead of the trigger's handler.
+    triggerRef.current?.focus();
+  }, [triggerRef]);
+
+  const commit = useCallback((index: number) => {
+    onChange(normalized[index].value);
+    setIsOpen(false);
+  }, [normalized, onChange]);
+
+  const handleTriggerKeyDown = (e: React.KeyboardEvent) => {
+    if (!isOpen) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMenu(selectedIndex >= 0 ? selectedIndex : 0);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        openMenu(selectedIndex >= 0 ? selectedIndex : normalized.length - 1);
+      }
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % normalized.length);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((i) => (i - 1 + normalized.length) % normalized.length);
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(normalized.length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (activeIndex >= 0) commit(activeIndex);
+        break;
+      case 'Escape':
+        e.preventDefault();
+        setIsOpen(false);
+        break;
+      case 'Tab':
+        setIsOpen(false);
+        break;
+    }
+  };
+
+  // Close when focus leaves the trigger (Tab away, or focus moves elsewhere).
+  const handleTriggerBlur = (e: React.FocusEvent) => {
+    const next = e.relatedTarget as Node | null;
+    if (floatingRef.current?.contains(next)) return;
+    setIsOpen(false);
+  };
+
+  // Close on click outside (covers clicks on non-focusable areas that don't
+  // blur the trigger).
   useEffect(() => {
     if (!isOpen) return;
 
@@ -59,7 +125,7 @@ export function SelectControl({ label, value, options, onChange }: SelectControl
       const target = e.target as Node;
       if (
         triggerRef.current && !triggerRef.current.contains(target) &&
-        dropdownRef.current && !dropdownRef.current.contains(target)
+        floatingRef.current && !floatingRef.current.contains(target)
       ) {
         setIsOpen(false);
       }
@@ -67,15 +133,21 @@ export function SelectControl({ label, value, options, onChange }: SelectControl
 
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
-  }, [isOpen]);
+  }, [isOpen, triggerRef, floatingRef]);
 
   return (
     <div className="dialkit-select-row">
       <button
         ref={triggerRef}
         className="dialkit-select-trigger"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={() => (isOpen ? setIsOpen(false) : openMenu(selectedIndex >= 0 ? selectedIndex : 0))}
+        onKeyDown={handleTriggerKeyDown}
+        onBlur={handleTriggerBlur}
         data-open={String(isOpen)}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        aria-controls={isOpen ? `${baseId}-listbox` : undefined}
+        aria-activedescendant={isOpen && activeIndex >= 0 ? optionId(activeIndex) : undefined}
       >
         <span className="dialkit-select-label">{label}</span>
         <div className="dialkit-select-right">
@@ -98,31 +170,33 @@ export function SelectControl({ label, value, options, onChange }: SelectControl
 
       {portalTarget && createPortal(
         <AnimatePresence>
-          {isOpen && pos && (
+          {isOpen && (
             <motion.div
-              ref={dropdownRef}
+              ref={floatingRef}
+              id={`${baseId}-listbox`}
               className="dialkit-select-dropdown"
-              initial={{ opacity: 0, y: pos.above ? 8 : -8, scale: 0.95 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: pos.above ? 8 : -8, scale: 0.95 }}
+              role="listbox"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
               transition={{ type: 'spring', visualDuration: 0.15, bounce: 0 }}
-              style={{
-                position: 'absolute',
-                left: pos.left,
-                top: pos.top,
-                width: pos.width,
-                transformOrigin: pos.above ? 'bottom' : 'top',
-              }}
+              style={{ position: 'fixed', top: 0, left: 0 }}
             >
-              {normalized.map((option) => (
+              {normalized.map((option, index) => (
                 <button
                   key={option.value}
+                  id={optionId(index)}
+                  ref={(el) => { optionRefs.current[index] = el; }}
+                  type="button"
                   className="dialkit-select-option"
+                  role="option"
+                  aria-selected={option.value === value}
+                  tabIndex={-1}
                   data-selected={String(option.value === value)}
-                  onClick={() => {
-                    onChange(option.value);
-                    setIsOpen(false);
-                  }}
+                  data-active={String(index === activeIndex)}
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => commit(index)}
+                  onMouseEnter={() => setActiveIndex(index)}
                 >
                   {option.label}
                 </button>

--- a/src/components/ShortcutsMenu.tsx
+++ b/src/components/ShortcutsMenu.tsx
@@ -1,7 +1,8 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
 import { DialStore, ShortcutConfig } from '../store/DialStore';
+import { useFloatingDropdown } from '../hooks/useFloatingDropdown';
 
 interface ShortcutsMenuProps {
   panelId: string;
@@ -28,15 +29,11 @@ function formatInteraction(sc: ShortcutConfig): string {
 
 export function ShortcutsMenu({ panelId }: ShortcutsMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState({ top: 0, right: 0 });
+  const { triggerRef, floatingRef } = useFloatingDropdown<HTMLButtonElement, HTMLDivElement>(isOpen, {
+    placement: 'bottom-end',
+  });
 
   const open = useCallback(() => {
-    const rect = triggerRef.current?.getBoundingClientRect();
-    if (rect) {
-      setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
-    }
     setIsOpen(true);
   }, []);
 
@@ -55,7 +52,7 @@ export function ShortcutsMenu({ panelId }: ShortcutsMenuProps) {
       const target = e.target as Node;
       if (
         triggerRef.current?.contains(target) ||
-        dropdownRef.current?.contains(target)
+        floatingRef.current?.contains(target)
       ) return;
       close();
     };
@@ -114,9 +111,9 @@ export function ShortcutsMenu({ panelId }: ShortcutsMenuProps) {
         <AnimatePresence>
           {isOpen && (
             <motion.div
-              ref={dropdownRef}
+              ref={floatingRef}
               className="dialkit-root dialkit-shortcuts-dropdown"
-              style={{ position: 'fixed', top: pos.top, right: pos.right }}
+              style={{ position: 'fixed', top: 0, left: 0 }}
               initial={{ opacity: 0, y: 4, scale: 0.97 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
               exit={{ opacity: 0, y: 4, scale: 0.97, pointerEvents: 'none' as any }}

--- a/src/components/Slider.tsx
+++ b/src/components/Slider.tsx
@@ -39,6 +39,7 @@ export function Slider({
   const [isInteracting, setIsInteracting] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
   const [isValueHovered, setIsValueHovered] = useState(false);
   const [isValueEditable, setIsValueEditable] = useState(false);
   const [showInput, setShowInput] = useState(false);
@@ -53,7 +54,7 @@ export function Slider({
   const scaleRef = useRef(1);
 
   const percentage = ((value - min) / (max - min)) * 100;
-  const isActive = isInteracting || isHovered;
+  const isActive = isInteracting || isHovered || isFocused;
 
   // Motion values for imperative animation
   const fillPercent = useMotionValue(percentage);
@@ -299,6 +300,38 @@ export function Slider({
     handleInputSubmit();
   };
 
+  const handleTrackKeyDown = (e: React.KeyboardEvent) => {
+    let next: number | null = null;
+    const bigStep = step * 10;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        next = value + step;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        next = value - step;
+        break;
+      case 'PageUp':
+        next = value + bigStep;
+        break;
+      case 'PageDown':
+        next = value - bigStep;
+        break;
+      case 'Home':
+        next = min;
+        break;
+      case 'End':
+        next = max;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    const clamped = Math.max(min, Math.min(max, next));
+    onChange(roundValue(clamped, step));
+  };
+
   const displayValue = value.toFixed(decimalsForStep(step));
 
   // Handle opacity: not active → 0, active → 0.5, dragging → 0.9
@@ -361,6 +394,16 @@ export function Slider({
         onPointerUp={handlePointerUp}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
+        onKeyDown={handleTrackKeyDown}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        tabIndex={showInput ? -1 : 0}
+        role="slider"
+        aria-label={label}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        aria-valuetext={unit ? `${displayValue}${unit}` : displayValue}
         style={{ width: rubberBandWidth, x: rubberBandX }}
       >
         <div className="dialkit-slider-hashmarks">{hashMarks}</div>

--- a/src/dropdown-position.ts
+++ b/src/dropdown-position.ts
@@ -1,35 +1,48 @@
-export type DropdownPosition = {
-  top: number;
-  left: number;
-  width: number;
-  above: boolean;
-};
+import { computePosition, autoUpdate, offset, flip, shift, size, type Placement } from '@floating-ui/dom';
 
-export type DropdownPositionOptions = {
-  dropdownHeight?: number;
+export type AttachDropdownOptions = {
+  placement?: Placement;
   gap?: number;
-  allowAbove?: boolean;
+  matchWidth?: boolean;
+  padding?: number;
+  onPlacement?: (placement: Placement) => void;
 };
 
-export function getDropdownPosition(
+/**
+ * Tether a floating element to a trigger using Floating UI. `autoUpdate` keeps
+ * it glued through scrolling ancestors, resize, and layout shifts, and
+ * flip/shift keep it on-screen. Returns a cleanup function to detach.
+ */
+export function attachDropdown(
   trigger: HTMLElement,
-  portalRoot: HTMLElement,
-  options: DropdownPositionOptions = {}
-): DropdownPosition {
-  const { dropdownHeight = 0, gap = 4, allowAbove = true } = options;
-  const triggerRect = trigger.getBoundingClientRect();
-  const rootRect = portalRoot.getBoundingClientRect();
-  const spaceBelow = window.innerHeight - triggerRect.bottom - gap;
-  const above = allowAbove && spaceBelow < dropdownHeight && triggerRect.top > spaceBelow;
+  floating: HTMLElement,
+  options: AttachDropdownOptions = {}
+): () => void {
+  const { placement = 'bottom-start', gap = 4, matchWidth = false, padding = 8, onPlacement } = options;
 
-  return {
-    top: above
-      ? triggerRect.top - rootRect.top - dropdownHeight - gap
-      : triggerRect.bottom - rootRect.top + gap,
-    left: triggerRect.left - rootRect.left,
-    width: triggerRect.width,
-    above,
+  const middleware = [offset(gap), flip({ padding }), shift({ padding })];
+  if (matchWidth) {
+    middleware.push(
+      size({
+        apply({ rects, elements }) {
+          elements.floating.style.minWidth = `${rects.reference.width}px`;
+        },
+      })
+    );
+  }
+
+  const update = () => {
+    computePosition(trigger, floating, { strategy: 'fixed', placement, middleware }).then(
+      ({ x, y, placement: resolved }) => {
+        floating.style.position = 'fixed';
+        floating.style.left = `${x}px`;
+        floating.style.top = `${y}px`;
+        onPlacement?.(resolved);
+      }
+    );
   };
+
+  return autoUpdate(trigger, floating, update);
 }
 
 export function getDialKitPortalRoot(trigger: HTMLElement | null | undefined): HTMLElement | null {

--- a/src/hooks/useFloatingDropdown.ts
+++ b/src/hooks/useFloatingDropdown.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+import { attachDropdown, type AttachDropdownOptions } from '../dropdown-position';
+
+/**
+ * Tethers a floating dropdown to a trigger via Floating UI while `isOpen`.
+ * Returns refs to attach to the trigger and the floating element. Positioning
+ * stays glued through scroll/resize/layout shifts — no manual recompute.
+ */
+export function useFloatingDropdown<T extends HTMLElement, F extends HTMLElement>(
+  isOpen: boolean,
+  options: AttachDropdownOptions = {}
+) {
+  const triggerRef = useRef<T>(null);
+  const floatingRef = useRef<F>(null);
+  // Keep the latest options without retriggering the effect on every render.
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    if (!isOpen || !triggerRef.current || !floatingRef.current) return;
+    return attachDropdown(triggerRef.current, floatingRef.current, optionsRef.current);
+  }, [isOpen]);
+
+  return { triggerRef, floatingRef };
+}

--- a/src/solid/components/Folder.tsx
+++ b/src/solid/components/Folder.tsx
@@ -125,6 +125,17 @@ export function Folder(props: FolderProps) {
     props.onOpenChange?.(next);
   };
 
+  const handleToggleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleToggle();
+    }
+  };
+
+  // The header toggles the folder. For a root panel it's only interactive
+  // while open (collapsing it); the collapsed circle handles re-opening.
+  const headerInteractive = () => (props.isRoot ? isOpen() && !props.inline : true);
+
   const folderContent = () => (
     <div
       ref={(el) => { if (props.isRoot) contentRef = el; }}
@@ -134,6 +145,11 @@ export function Folder(props: FolderProps) {
       <div
         class={`dialkit-folder-header ${props.isRoot ? 'dialkit-panel-header' : ''}`}
         onClick={handleToggle}
+        role={headerInteractive() ? 'button' : undefined}
+        tabindex={headerInteractive() ? 0 : undefined}
+        aria-expanded={headerInteractive() ? isOpen() : undefined}
+        aria-label={headerInteractive() ? props.title : undefined}
+        onKeyDown={headerInteractive() ? handleToggleKeyDown : undefined}
       >
         <div class="dialkit-folder-header-top">
           {props.isRoot ? (
@@ -299,6 +315,11 @@ export function Folder(props: FolderProps) {
         ref={panelRef}
         class="dialkit-panel-inner"
         data-collapsed={String(isCollapsed())}
+        role={!isOpen() ? 'button' : undefined}
+        tabindex={!isOpen() ? 0 : undefined}
+        aria-expanded={!isOpen() ? false : undefined}
+        aria-label={!isOpen() ? props.title : undefined}
+        onKeyDown={!isOpen() ? handleToggleKeyDown : undefined}
         onPointerDown={() => {
           if (isOpen()) return;
           (document.activeElement as HTMLElement)?.blur?.();

--- a/src/solid/components/PresetManager.tsx
+++ b/src/solid/components/PresetManager.tsx
@@ -1,8 +1,9 @@
-import { createSignal, createEffect, onMount, onCleanup, Show, For } from 'solid-js';
+import { createSignal, createEffect, onMount, onCleanup, createUniqueId, Show, For } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { animate } from 'motion';
 import { ICON_CHEVRON, ICON_TRASH } from '../../icons';
-import { getDialKitPortalRoot, getDropdownPosition } from '../../dropdown-position';
+import { getDialKitPortalRoot } from '../../dropdown-position';
+import { useFloatingDropdown } from '../floating';
 import { DialStore } from '../../store/DialStore';
 import type { Preset } from '../../store/DialStore';
 
@@ -16,16 +17,28 @@ interface PresetManagerProps {
 export function PresetManager(props: PresetManagerProps) {
   const [isOpen, setIsOpen] = createSignal(false);
   const [mounted, setMounted] = createSignal(false);
-  const [pos, setPos] = createSignal({ top: 0, left: 0, width: 0 });
+  const [activeIndex, setActiveIndex] = createSignal(-1);
   const [portalTarget, setPortalTarget] = createSignal<HTMLElement | null>(null);
+  const [dropdownEl, setDropdownEl] = createSignal<HTMLDivElement | undefined>();
   let triggerRef!: HTMLButtonElement;
-  let dropdownRef: HTMLDivElement | undefined;
   let chevronRef!: SVGSVGElement;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let closeAnim: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let chevronAnim: any = null;
+
+  const baseId = createUniqueId();
+  const optionId = (index: number) => `${baseId}-opt-${index}`;
 
   const hasPresets = () => props.presets.length > 0;
   const activePreset = () => props.presets.find((p) => p.id === props.activePresetId);
+
+  // Flat selectable list: the implicit "Version 1" (no preset) plus each preset.
+  const items = (): { id: string | null; name: string }[] => [
+    { id: null, name: 'Version 1' },
+    ...props.presets.map((p) => ({ id: p.id, name: p.name })),
+  ];
+  const selectedIndex = () => Math.max(0, items().findIndex((it) => it.id === props.activePresetId));
 
   onMount(() => {
     setPortalTarget(getDialKitPortalRoot(triggerRef) ?? document.body);
@@ -53,59 +66,125 @@ export function PresetManager(props: PresetManagerProps) {
     );
   });
 
-  const updatePos = () => {
-    const root = portalTarget();
-    if (!triggerRef || !root) return;
-    setPos(getDropdownPosition(triggerRef, root, { allowAbove: false }));
-  };
+  // Floating UI positioning while open.
+  useFloatingDropdown(
+    () => isOpen() && mounted(),
+    () => triggerRef,
+    () => dropdownEl(),
+    { placement: 'bottom-start', matchWidth: true }
+  );
 
-  const openDropdown = () => {
+  // Keep the active item scrolled into view.
+  createEffect(() => {
+    if (isOpen() && activeIndex() >= 0) {
+      document.getElementById(optionId(activeIndex()))?.scrollIntoView({ block: 'nearest' });
+    }
+  });
+
+  const openMenu = (toIndex: number) => {
     if (!hasPresets()) return;
-    updatePos();
     closeAnim?.stop();
     closeAnim = null;
+    setActiveIndex(toIndex);
     setMounted(true);
     setIsOpen(true);
+    // macOS Safari/Firefox don't focus a <button> on click — force it so the
+    // trigger's key handler receives arrow keys.
+    triggerRef?.focus();
   };
 
   const closeDropdown = () => {
     setIsOpen(false);
-    if (!dropdownRef) { setMounted(false); return; }
+    const el = dropdownEl();
+    if (!el) { setMounted(false); return; }
     closeAnim?.stop();
     closeAnim = animate(
-      dropdownRef,
+      el,
       { opacity: 0, y: 4, scale: 0.97 },
       { type: 'spring', visualDuration: 0.15, bounce: 0, onComplete: () => { setMounted(false); closeAnim = null; } }
     );
   };
 
-  const toggle = () => { if (isOpen()) closeDropdown(); else openDropdown(); };
-
-  // Close on click outside
-  createEffect(() => {
-    if (!isOpen()) return;
-    const handleViewportChange = () => updatePos();
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (triggerRef?.contains(target) || dropdownRef?.contains(target)) return;
-      closeDropdown();
-    };
-    updatePos();
-    document.addEventListener('mousedown', handler);
-    window.addEventListener('resize', handleViewportChange);
-    window.addEventListener('scroll', handleViewportChange, true);
-    onCleanup(() => {
-      document.removeEventListener('mousedown', handler);
-      window.removeEventListener('resize', handleViewportChange);
-      window.removeEventListener('scroll', handleViewportChange, true);
-    });
-  });
+  const toggle = () => { if (isOpen()) closeDropdown(); else openMenu(selectedIndex()); };
 
   const handleSelect = (presetId: string | null) => {
     if (presetId) DialStore.loadPreset(props.panelId, presetId);
     else DialStore.clearActivePreset(props.panelId);
     closeDropdown();
   };
+
+  const handleTriggerKeyDown = (e: KeyboardEvent) => {
+    if (!isOpen()) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMenu(selectedIndex());
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        openMenu(items().length - 1);
+      }
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % items().length);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((i) => (i - 1 + items().length) % items().length);
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(items().length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (activeIndex() >= 0) handleSelect(items()[activeIndex()].id);
+        break;
+      case 'Delete':
+      case 'Backspace': {
+        const target = items()[activeIndex()];
+        if (target?.id) {
+          e.preventDefault();
+          DialStore.deletePreset(props.panelId, target.id);
+          setActiveIndex((i) => Math.max(0, i - 1));
+        }
+        break;
+      }
+      case 'Escape':
+        e.preventDefault();
+        closeDropdown();
+        break;
+      case 'Tab':
+        closeDropdown();
+        break;
+    }
+  };
+
+  // Close when focus leaves the trigger.
+  const handleTriggerBlur = (e: FocusEvent) => {
+    const next = e.relatedTarget as Node | null;
+    if (dropdownEl()?.contains(next)) return;
+    closeDropdown();
+  };
+
+  // Close on mousedown outside trigger + dropdown.
+  createEffect(() => {
+    if (!isOpen()) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      const el = dropdownEl();
+      if (triggerRef?.contains(target) || el?.contains(target)) return;
+      closeDropdown();
+    };
+    document.addEventListener('mousedown', handler);
+    onCleanup(() => document.removeEventListener('mousedown', handler));
+  });
 
   const handleDelete = (e: MouseEvent, presetId: string) => {
     e.stopPropagation();
@@ -118,9 +197,15 @@ export function PresetManager(props: PresetManagerProps) {
         ref={triggerRef}
         class="dialkit-preset-trigger"
         onClick={toggle}
+        onKeyDown={handleTriggerKeyDown}
+        onBlur={handleTriggerBlur}
         data-open={String(isOpen())}
         data-has-preset={String(!!activePreset())}
         data-disabled={String(!hasPresets())}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen()}
+        aria-controls={isOpen() ? `${baseId}-listbox` : undefined}
+        aria-activedescendant={isOpen() && activeIndex() >= 0 ? optionId(activeIndex()) : undefined}
       >
         <span class="dialkit-preset-label">
           {activePreset() ? activePreset()!.name : 'Version 1'}
@@ -144,50 +229,49 @@ export function PresetManager(props: PresetManagerProps) {
           <Show when={mounted()}>
             <div
               ref={(el) => {
-                dropdownRef = el;
+                setDropdownEl(el);
                 animate(
                   el,
                   { opacity: [0, 1], y: [4, 0], scale: [0.97, 1] },
                   { type: 'spring', visualDuration: 0.15, bounce: 0 }
                 );
               }}
+              id={`${baseId}-listbox`}
               class="dialkit-root dialkit-preset-dropdown"
-              style={{
-                position: 'absolute',
-                top: `${pos().top}px`,
-                left: `${pos().left}px`,
-                'min-width': `${pos().width}px`,
-              }}
+              role="listbox"
+              style={{ position: 'fixed', top: '0', left: '0' }}
             >
-              <div
-                class="dialkit-preset-item"
-                data-active={String(!props.activePresetId)}
-                onClick={() => handleSelect(null)}
-              >
-                <span class="dialkit-preset-name">Version 1</span>
-              </div>
-
-              <For each={props.presets}>
-                {(preset) => (
+              <For each={items()}>
+                {(item, index) => (
                   <div
+                    id={optionId(index())}
                     class="dialkit-preset-item"
-                    data-active={String(preset.id === props.activePresetId)}
-                    onClick={() => handleSelect(preset.id)}
+                    role="option"
+                    aria-selected={index() === selectedIndex()}
+                    data-active={String(index() === activeIndex())}
+                    data-selected={String(index() === selectedIndex())}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onMouseEnter={() => setActiveIndex(index())}
+                    onClick={() => handleSelect(item.id)}
                   >
-                    <span class="dialkit-preset-name">{preset.name}</span>
-                    <button
-                      class="dialkit-preset-delete"
-                      onClick={(e) => handleDelete(e, preset.id)}
-                      title="Delete preset"
-                    >
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d={ICON_TRASH[0]} />
-                        <path d={ICON_TRASH[1]} />
-                        <path d={ICON_TRASH[2]} />
-                        <path d={ICON_TRASH[3]} />
-                        <path d={ICON_TRASH[4]} />
-                      </svg>
-                    </button>
+                    <span class="dialkit-preset-name">{item.name}</span>
+                    <Show when={item.id}>
+                      <button
+                        class="dialkit-preset-delete"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={(e) => handleDelete(e, item.id!)}
+                        title="Delete preset"
+                        tabindex={-1}
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                          <path d={ICON_TRASH[0]} />
+                          <path d={ICON_TRASH[1]} />
+                          <path d={ICON_TRASH[2]} />
+                          <path d={ICON_TRASH[3]} />
+                          <path d={ICON_TRASH[4]} />
+                        </svg>
+                      </button>
+                    </Show>
                   </div>
                 )}
               </For>

--- a/src/solid/components/SegmentedControl.tsx
+++ b/src/solid/components/SegmentedControl.tsx
@@ -9,10 +9,12 @@ interface SegmentedControlProps<T extends string> {
   options: SegmentedControlOption<T>[];
   value: T;
   onChange: (value: T) => void;
+  label?: string;
 }
 
 export function SegmentedControl<T extends string>(props: SegmentedControlProps<T>) {
   let containerRef: HTMLDivElement | undefined;
+  const buttonRefs: (HTMLButtonElement | undefined)[] = [];
   let hasAnimated = false;
   const [pillStyle, setPillStyle] = createSignal<{ left: number; width: number } | null>(null);
 
@@ -41,8 +43,43 @@ export function SegmentedControl<T extends string>(props: SegmentedControlProps<
     return 'left 0.2s cubic-bezier(0.25, 1, 0.5, 1), width 0.2s cubic-bezier(0.25, 1, 0.5, 1)';
   };
 
+  const activeIndex = () =>
+    Math.max(0, props.options.findIndex((o) => o.value === props.value));
+
+  // Radiogroup arrow-key navigation: moving focus also moves selection,
+  // matching the WAI-ARIA radio pattern.
+  const handleKeyDown = (e: KeyboardEvent, index: number) => {
+    let nextIndex: number | null = null;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIndex = (index + 1) % props.options.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIndex = (index - 1 + props.options.length) % props.options.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = props.options.length - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    props.onChange(props.options[nextIndex].value);
+    buttonRefs[nextIndex]?.focus();
+  };
+
   return (
-    <div class="dialkit-segmented" ref={containerRef}>
+    <div
+      class="dialkit-segmented"
+      ref={containerRef}
+      role="radiogroup"
+      aria-label={props.label}
+    >
       <Show when={pillStyle()}>
         {(style) => (
           <div
@@ -56,9 +93,15 @@ export function SegmentedControl<T extends string>(props: SegmentedControlProps<
         )}
       </Show>
       <For each={props.options}>
-        {(option) => (
+        {(option, index) => (
           <button
+            ref={(el) => { buttonRefs[index()] = el; }}
+            type="button"
+            role="radio"
+            aria-checked={props.value === option.value}
+            tabindex={index() === activeIndex() ? 0 : -1}
             onClick={() => props.onChange(option.value)}
+            onKeyDown={(e) => handleKeyDown(e, index())}
             class="dialkit-segmented-button"
             data-active={String(props.value === option.value)}
           >

--- a/src/solid/components/SelectControl.tsx
+++ b/src/solid/components/SelectControl.tsx
@@ -1,7 +1,8 @@
-import { createSignal, createEffect, onMount, onCleanup, Show, For } from 'solid-js';
+import { createSignal, createEffect, onMount, onCleanup, createUniqueId, Show, For } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { animate } from 'motion';
-import { getDialKitPortalRoot, getDropdownPosition } from '../../dropdown-position';
+import { getDialKitPortalRoot } from '../../dropdown-position';
+import { useFloatingDropdown } from '../floating';
 import { ICON_CHEVRON } from '../../icons';
 
 type SelectOption = string | { value: string; label: string };
@@ -26,15 +27,22 @@ function normalizeOptions(options: SelectOption[]): { value: string; label: stri
 export function SelectControl(props: SelectControlProps) {
   const [isOpen, setIsOpen] = createSignal(false);
   const [mounted, setMounted] = createSignal(false);
-  const [pos, setPos] = createSignal<{ top: number; left: number; width: number; above: boolean } | null>(null);
+  const [activeIndex, setActiveIndex] = createSignal(-1);
   const [portalTarget, setPortalTarget] = createSignal<HTMLElement | null>(null);
+  const [dropdownEl, setDropdownEl] = createSignal<HTMLDivElement | undefined>();
   let triggerRef!: HTMLButtonElement;
-  let dropdownRef: HTMLDivElement | undefined;
   let chevronRef!: SVGSVGElement;
+  const optionRefs: (HTMLButtonElement | undefined)[] = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let closeAnim: any = null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let chevronAnim: any = null;
 
+  const baseId = createUniqueId();
+  const optionId = (index: number) => `${baseId}-opt-${index}`;
+
   const normalized = () => normalizeOptions(props.options);
+  const selectedIndex = () => normalized().findIndex((o) => o.value === props.value);
   const selectedOption = () => normalized().find((o) => o.value === props.value);
 
   onMount(() => {
@@ -61,78 +69,132 @@ export function SelectControl(props: SelectControlProps) {
     );
   });
 
-  const updatePos = () => {
-    const root = portalTarget();
-    if (!triggerRef || !root) return;
-    const dropdownHeight = 8 + normalized().length * 36;
-    setPos(getDropdownPosition(triggerRef, root, { dropdownHeight }));
-  };
+  // Floating UI positioning while open.
+  useFloatingDropdown(
+    () => isOpen() && mounted(),
+    () => triggerRef,
+    () => dropdownEl(),
+    { placement: 'bottom-start', matchWidth: true }
+  );
 
-  const openDropdown = () => {
+  // Focus never leaves the trigger — the active option is tracked with
+  // aria-activedescendant. Keep the active option scrolled into view.
+  createEffect(() => {
+    if (isOpen() && activeIndex() >= 0) {
+      optionRefs[activeIndex()]?.scrollIntoView({ block: 'nearest' });
+    }
+  });
+
+  const openMenu = (toIndex: number) => {
     closeAnim?.stop();
     closeAnim = null;
-    updatePos();
+    setActiveIndex(toIndex);
     setMounted(true);
     setIsOpen(true);
+    // macOS Safari/Firefox don't focus a <button> on click, so force it —
+    // otherwise arrow keys hit the page instead of the trigger's handler.
+    triggerRef?.focus();
+  };
+
+  const commit = (index: number) => {
+    props.onChange(normalized()[index].value);
+    closeDropdown();
   };
 
   const closeDropdown = () => {
     setIsOpen(false);
-    if (!dropdownRef) { setMounted(false); return; }
-    const above = pos()?.above ?? false;
+    const el = dropdownEl();
+    if (!el) { setMounted(false); return; }
     closeAnim?.stop();
     closeAnim = animate(
-      dropdownRef,
-      { opacity: 0, y: above ? 8 : -8, scale: 0.95 },
+      el,
+      { opacity: 0, y: -8, scale: 0.95 },
       { type: 'spring', visualDuration: 0.15, bounce: 0, onComplete: () => { setMounted(false); closeAnim = null; } }
     );
   };
 
-  // Close on click outside
+  const handleTriggerKeyDown = (e: KeyboardEvent) => {
+    if (!isOpen()) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMenu(selectedIndex() >= 0 ? selectedIndex() : 0);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        openMenu(selectedIndex() >= 0 ? selectedIndex() : normalized().length - 1);
+      }
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % normalized().length);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        setActiveIndex((i) => (i - 1 + normalized().length) % normalized().length);
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(normalized().length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (activeIndex() >= 0) commit(activeIndex());
+        break;
+      case 'Escape':
+        e.preventDefault();
+        closeDropdown();
+        break;
+      case 'Tab':
+        closeDropdown();
+        break;
+    }
+  };
+
+  // Close when focus leaves the trigger (Tab away, or focus moves elsewhere).
+  const handleTriggerBlur = (e: FocusEvent) => {
+    const next = e.relatedTarget as Node | null;
+    if (dropdownEl()?.contains(next)) return;
+    closeDropdown();
+  };
+
+  // Close on click outside (covers clicks on non-focusable areas).
   createEffect(() => {
     if (!isOpen()) return;
-    const handleViewportChange = () => updatePos();
 
     const handleClick = (e: MouseEvent) => {
       const target = e.target as Node;
+      const el = dropdownEl();
       if (
         triggerRef && !triggerRef.contains(target) &&
-        dropdownRef && !dropdownRef.contains(target)
+        el && !el.contains(target)
       ) {
         closeDropdown();
       }
     };
 
-    updatePos();
     document.addEventListener('mousedown', handleClick);
-    window.addEventListener('resize', handleViewportChange);
-    window.addEventListener('scroll', handleViewportChange, true);
-    onCleanup(() => {
-      document.removeEventListener('mousedown', handleClick);
-      window.removeEventListener('resize', handleViewportChange);
-      window.removeEventListener('scroll', handleViewportChange, true);
-    });
+    onCleanup(() => document.removeEventListener('mousedown', handleClick));
   });
-
-  const dropdownStyle = () => {
-    const p = pos();
-    if (!p) return {};
-    return {
-      position: 'absolute' as const,
-      left: `${p.left}px`,
-      top: `${p.top}px`,
-      width: `${p.width}px`,
-      'transform-origin': p.above ? 'bottom' : 'top',
-    };
-  };
 
   return (
     <div class="dialkit-select-row">
       <button
         ref={triggerRef}
         class="dialkit-select-trigger"
-        onClick={() => isOpen() ? closeDropdown() : openDropdown()}
+        onClick={() => (isOpen() ? closeDropdown() : openMenu(selectedIndex() >= 0 ? selectedIndex() : 0))}
+        onKeyDown={handleTriggerKeyDown}
+        onBlur={handleTriggerBlur}
         data-open={String(isOpen())}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen()}
+        aria-controls={isOpen() ? `${baseId}-listbox` : undefined}
+        aria-activedescendant={isOpen() && activeIndex() >= 0 ? optionId(activeIndex()) : undefined}
       >
         <span class="dialkit-select-label">{props.label}</span>
         <div class="dialkit-select-right">
@@ -154,29 +216,36 @@ export function SelectControl(props: SelectControlProps) {
 
       <Show when={!!portalTarget()}>
         <Portal mount={portalTarget()!}>
-          <Show when={mounted() && pos()}>
+          <Show when={mounted()}>
             <div
               ref={(el) => {
-                dropdownRef = el;
-                const above = pos()?.above ?? false;
+                setDropdownEl(el);
                 animate(
                   el,
-                  { opacity: [0, 1], y: [above ? 8 : -8, 0], scale: [0.95, 1] },
+                  { opacity: [0, 1], y: [-8, 0], scale: [0.95, 1] },
                   { type: 'spring', visualDuration: 0.15, bounce: 0 }
                 );
               }}
+              id={`${baseId}-listbox`}
               class="dialkit-select-dropdown"
-              style={dropdownStyle()}
+              role="listbox"
+              style={{ position: 'fixed', top: '0', left: '0' }}
             >
               <For each={normalized()}>
-                {(option) => (
+                {(option, index) => (
                   <button
+                    id={optionId(index())}
+                    ref={(el) => { optionRefs[index()] = el; }}
+                    type="button"
                     class="dialkit-select-option"
+                    role="option"
+                    aria-selected={option.value === props.value}
+                    tabindex={-1}
                     data-selected={String(option.value === props.value)}
-                    onClick={() => {
-                      props.onChange(option.value);
-                      closeDropdown();
-                    }}
+                    data-active={String(index() === activeIndex())}
+                    onMouseDown={(e) => e.preventDefault()}
+                    onClick={() => commit(index())}
+                    onMouseEnter={() => setActiveIndex(index())}
                   >
                     {option.label}
                   </button>

--- a/src/solid/components/ShortcutsMenu.tsx
+++ b/src/solid/components/ShortcutsMenu.tsx
@@ -1,6 +1,7 @@
-import { createSignal, createEffect, onCleanup, Show, For } from 'solid-js';
+import { createSignal, createEffect, onCleanup, For } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { animate } from 'motion';
+import { useFloatingDropdown } from '../floating';
 import { DialStore, ShortcutConfig } from '../../store/DialStore';
 
 interface ShortcutsMenuProps {
@@ -28,7 +29,6 @@ function formatInteraction(sc: ShortcutConfig): string {
 
 export function ShortcutsMenu(props: ShortcutsMenuProps) {
   const [isOpen, setIsOpen] = createSignal(false);
-  const [pos, setPos] = createSignal({ top: 0, right: 0 });
 
   let triggerRef!: HTMLButtonElement;
   let dropdownRef: HTMLDivElement | undefined;
@@ -42,15 +42,17 @@ export function ShortcutsMenu(props: ShortcutsMenuProps) {
 
   const tapTransition = { type: 'spring' as const, visualDuration: 0.15, bounce: 0.3 };
 
-  const open = () => {
-    const rect = triggerRef?.getBoundingClientRect();
-    if (rect) {
-      setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
-    }
-    setIsOpen(true);
-  };
+  const open = () => setIsOpen(true);
 
   const close = () => setIsOpen(false);
+
+  // Floating UI positioning while open.
+  useFloatingDropdown(
+    isOpen,
+    () => triggerRef,
+    () => dropdownRef,
+    { placement: 'bottom-end' }
+  );
 
   const toggle = () => {
     if (isOpen()) close();
@@ -172,11 +174,7 @@ export function ShortcutsMenu(props: ShortcutsMenuProps) {
             el.style.pointerEvents = 'none';
           }}
           class="dialkit-root dialkit-shortcuts-dropdown"
-          style={{
-            position: 'fixed',
-            top: `${pos().top}px`,
-            right: `${pos().right}px`,
-          }}
+          style={{ position: 'fixed', top: '0', left: '0' }}
         >
           <div class="dialkit-shortcuts-title">Keyboard Shortcuts</div>
           <div class="dialkit-shortcuts-list">

--- a/src/solid/components/Slider.tsx
+++ b/src/solid/components/Slider.tsx
@@ -41,6 +41,7 @@ export function Slider(props: SliderProps) {
   const [isInteracting, setIsInteracting] = createSignal(false);
   const [isDragging, setIsDragging] = createSignal(false);
   const [isHovered, setIsHovered] = createSignal(false);
+  const [isFocused, setIsFocused] = createSignal(false);
   const [isValueHovered, setIsValueHovered] = createSignal(false);
   const [isValueEditable, setIsValueEditable] = createSignal(false);
   const [showInput, setShowInput] = createSignal(false);
@@ -77,7 +78,7 @@ export function Slider(props: SliderProps) {
   });
 
   const percentage = () => ((props.value - min()) / (max() - min())) * 100;
-  const isActive = () => isInteracting() || isHovered();
+  const isActive = () => isInteracting() || isHovered() || isFocused();
 
   let pointerDownPos: { x: number; y: number } | null = null;
   let isClickFlag = true;
@@ -292,6 +293,38 @@ export function Slider(props: SliderProps) {
     }
   };
 
+  const handleTrackKeyDown = (e: KeyboardEvent) => {
+    let next: number | null = null;
+    const bigStep = step() * 10;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        next = props.value + step();
+        break;
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        next = props.value - step();
+        break;
+      case 'PageUp':
+        next = props.value + bigStep;
+        break;
+      case 'PageDown':
+        next = props.value - bigStep;
+        break;
+      case 'Home':
+        next = min();
+        break;
+      case 'End':
+        next = max();
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    const clamped = Math.max(min(), Math.min(max(), next));
+    props.onChange(roundValue(clamped, step()));
+  };
+
   const displayValue = () => props.value.toFixed(decimalsForStep(step()));
 
   // Value dodge: fade handle when it overlaps label or value text
@@ -373,6 +406,16 @@ export function Slider(props: SliderProps) {
         onPointerCancel={handlePointerCancel}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
+        onKeyDown={handleTrackKeyDown}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        tabindex={showInput() ? -1 : 0}
+        role="slider"
+        aria-label={props.label}
+        aria-valuemin={min()}
+        aria-valuemax={max()}
+        aria-valuenow={props.value}
+        aria-valuetext={props.unit ? `${displayValue()}${props.unit}` : displayValue()}
       >
         <div class="dialkit-slider-hashmarks">{hashMarks()}</div>
 

--- a/src/solid/floating.ts
+++ b/src/solid/floating.ts
@@ -1,0 +1,24 @@
+import { createEffect, onCleanup, type Accessor } from 'solid-js';
+import { attachDropdown, type AttachDropdownOptions } from '../dropdown-position';
+
+/**
+ * Tethers a floating dropdown to a trigger via Floating UI while `isOpen`.
+ * While open and both elements exist, runs `attachDropdown` inside a
+ * createEffect and detaches via onCleanup. Positioning stays glued through
+ * scroll/resize/layout shifts — no manual recompute.
+ */
+export function useFloatingDropdown(
+  isOpen: Accessor<boolean>,
+  getTrigger: () => HTMLElement | null | undefined,
+  getFloating: () => HTMLElement | null | undefined,
+  options: AttachDropdownOptions = {}
+) {
+  createEffect(() => {
+    if (!isOpen()) return;
+    const trigger = getTrigger();
+    const floating = getFloating();
+    if (!trigger || !floating) return;
+    const cleanup = attachDropdown(trigger, floating, options);
+    onCleanup(cleanup);
+  });
+}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -16,6 +16,9 @@
   --dial-text-label: rgba(255, 255, 255, 0.7);   /* Input labels */
   --dial-text-focus: #ffffff;
 
+  /* Keyboard focus indicator */
+  --dial-focus-ring: #5b9dff;
+
   /* Legacy aliases */
   --dial-text-primary: rgba(255, 255, 255, 0.95);
   --dial-text-secondary: rgba(255, 255, 255, 0.6);
@@ -39,6 +42,61 @@
   font-family: system-ui, -apple-system, 'SF Pro Display', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* ── Keyboard focus indicators ──
+   A single visible ring for any keyboard-focused interactive element.
+   Uses :focus-visible so it never shows on mouse/touch interaction. */
+.dialkit-root :focus-visible {
+  /* Inset ring: the panel scrolls (overflow clips both axes), so an outward
+     offset ring gets cut off near the edges. Drawing it inside the element's
+     box keeps the full ring visible on every control. */
+  outline: 2px solid var(--dial-focus-ring);
+  /* Inset by only 1px so the ring hugs the element's edge (rather than biting
+     into the text) while staying inside the panel's scroll clip. */
+  outline-offset: -1px;
+  /* No border-radius override: the outline natively follows the element's own
+     corner radius, so the ring matches rounded and square controls alike. */
+}
+
+/* Inline transparent inputs sit flush inside a row and fill its width — a box
+   ring hugs the text and reads heavy. Show focus as an accent underline
+   instead (box-shadow avoids any layout shift). */
+.dialkit-root .dialkit-color-hex-input:focus-visible {
+  outline: none;
+  box-shadow: inset 0 -1.5px 0 var(--dial-focus-ring);
+  color: var(--dial-text-focus);
+}
+
+.dialkit-root .dialkit-slider-input:focus-visible {
+  outline: none;
+  border-bottom-color: var(--dial-focus-ring);
+  color: var(--dial-text-focus);
+}
+
+/* The text control's input spans the whole row, so ring the row itself
+   (like the select trigger) rather than the text. */
+.dialkit-root .dialkit-text-input:focus-visible {
+  outline: none;
+}
+
+.dialkit-root .dialkit-text-control:focus-within {
+  outline: 2px solid var(--dial-focus-ring);
+  outline-offset: -1px;
+  border-radius: var(--dial-radius);
+}
+
+/* The preset name field is a real bordered box — thicken its border to the
+   accent instead of an inset ring so text keeps its padding. */
+.dialkit-root .dialkit-preset-input:focus-visible {
+  outline: none;
+  border-color: var(--dial-focus-ring);
+  box-shadow: inset 0 0 0 1px var(--dial-focus-ring);
+}
+
+/* Remove the ring only for pointer focus; keep it for keyboard. */
+.dialkit-root :focus:not(:focus-visible) {
+  outline: none;
 }
 
 .dialkit-panel {
@@ -921,7 +979,8 @@
   transition: background 0.15s, color 0.15s;
 }
 
-.dialkit-select-option:hover {
+.dialkit-select-option:hover,
+.dialkit-select-option[data-active="true"] {
   background: var(--dial-surface-hover);
 }
 
@@ -1345,6 +1404,7 @@
   --dial-text-section: rgba(0, 0, 0, 0.65);
   --dial-text-label: rgba(0, 0, 0, 0.6);
   --dial-text-focus: #000000;
+  --dial-focus-ring: #0a6cff;
 
   --dial-text-primary: rgba(0, 0, 0, 0.9);
   --dial-text-secondary: rgba(0, 0, 0, 0.55);
@@ -1390,6 +1450,7 @@
     --dial-text-section: rgba(0, 0, 0, 0.65);
     --dial-text-label: rgba(0, 0, 0, 0.6);
     --dial-text-focus: #000000;
+    --dial-focus-ring: #0a6cff;
 
     --dial-text-primary: rgba(0, 0, 0, 0.9);
     --dial-text-secondary: rgba(0, 0, 0, 0.55);

--- a/src/svelte/components/Folder.svelte
+++ b/src/svelte/components/Folder.svelte
@@ -97,6 +97,17 @@
     onOpenChange?.(next);
   };
 
+  const handleToggleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleToggle();
+    }
+  };
+
+  // The header toggles the folder. For a root panel it's only interactive
+  // while open (collapsing it); the collapsed circle handles re-opening.
+  const headerInteractive = $derived(isRoot ? isOpen && !inline : true);
+
   const handleCollapsedTapStart = () => {
     if (isOpen) return;
     (document.activeElement as HTMLElement | null)?.blur?.();
@@ -152,9 +163,22 @@
     onpointercancel={handleCollapsedTapEnd}
     onpointerleave={handleCollapsedTapEnd}
     onclick={() => { if (!isOpen) handleToggle(); }}
+    role={!isOpen ? 'button' : undefined}
+    tabindex={!isOpen ? 0 : undefined}
+    aria-expanded={!isOpen ? false : undefined}
+    aria-label={!isOpen ? title : undefined}
+    onkeydown={!isOpen ? handleToggleKeyDown : undefined}
   >
     <div bind:this={contentRef} class="dialkit-folder dialkit-folder-root" data-open={String(isOpen)}>
-      <div class="dialkit-folder-header dialkit-panel-header" onclick={(e) => { e.stopPropagation(); handleToggle(); }}>
+      <div
+        class="dialkit-folder-header dialkit-panel-header"
+        onclick={(e) => { e.stopPropagation(); handleToggle(); }}
+        role={headerInteractive ? 'button' : undefined}
+        tabindex={headerInteractive ? 0 : undefined}
+        aria-expanded={headerInteractive ? isOpen : undefined}
+        aria-label={headerInteractive ? title : undefined}
+        onkeydown={headerInteractive ? handleToggleKeyDown : undefined}
+      >
         <div class="dialkit-folder-header-top">
           {#if isOpen}
             <div class="dialkit-folder-title-row">
@@ -192,7 +216,15 @@
   </div>
 {:else}
   <div class="dialkit-folder" data-open={String(isOpen)}>
-    <div class="dialkit-folder-header" onclick={handleToggle}>
+    <div
+      class="dialkit-folder-header"
+      onclick={handleToggle}
+      role="button"
+      tabindex={0}
+      aria-expanded={isOpen}
+      aria-label={title}
+      onkeydown={handleToggleKeyDown}
+    >
       <div class="dialkit-folder-header-top">
         <div class="dialkit-folder-title-row">
           <span class="dialkit-folder-title">{title}</span>

--- a/src/svelte/components/PresetManager.svelte
+++ b/src/svelte/components/PresetManager.svelte
@@ -4,7 +4,7 @@
   import { DialStore } from 'dialkit/store';
   import type { Preset } from 'dialkit/store';
   import { dropdownTransition } from './transitions';
-  import { getDialKitPortalRoot, getDropdownPosition } from '../../dropdown-position';
+  import { getDialKitPortalRoot, attachDropdown } from '../../dropdown-position';
   import { ICON_CHEVRON, ICON_TRASH } from '../../icons';
 
   let { panelId, presets, activePresetId } = $props<{
@@ -13,11 +13,13 @@
     activePresetId: string | null;
   }>();
 
+  const baseId = `dialkit-preset-${Math.random().toString(36).slice(2, 9)}`;
+
   let isOpen = $state(false);
-  let pos = $state({ top: 0, left: 0, width: 0 });
+  let activeIndex = $state(-1);
   let portalTarget = $state<HTMLElement | null>(null);
-  let triggerRef: HTMLButtonElement | undefined;
-  let dropdownRef: HTMLDivElement | undefined;
+  let triggerRef = $state<HTMLButtonElement | undefined>(undefined);
+  let dropdownRef = $state<HTMLDivElement | undefined>(undefined);
 
   const chevronRotation = new Spring(0, { stiffness: 0.2, damping: 0.6 });
   const chevronOpacity = new Spring(0.25, { stiffness: 0.2, damping: 0.6 });
@@ -25,19 +27,36 @@
   const hasPresets = $derived(presets.length > 0);
   const activePreset = $derived(presets.find((p: Preset) => p.id === activePresetId));
 
-  const updatePos = () => {
-    if (!triggerRef || !portalTarget) return;
-    pos = getDropdownPosition(triggerRef, portalTarget, { allowAbove: false });
-  };
+  // Flat selectable list: the implicit "Version 1" (no preset) plus each preset.
+  const items = $derived<{ id: string | null; name: string }[]>([
+    { id: null, name: 'Version 1' },
+    ...presets.map((p: Preset) => ({ id: p.id, name: p.name })),
+  ]);
+  const selectedIndex = $derived(
+    Math.max(0, items.findIndex((it) => it.id === activePresetId))
+  );
+  const optionId = (index: number) => `${baseId}-opt-${index}`;
 
-  const openDropdown = () => {
+  const close = () => (isOpen = false);
+
+  const openMenu = (toIndex: number) => {
     if (!hasPresets) return;
-    updatePos();
+    activeIndex = toIndex;
     isOpen = true;
+    // macOS Safari/Firefox don't focus a <button> on click — force it so the
+    // trigger's key handler receives arrow keys.
+    triggerRef?.focus();
   };
 
-  const closeDropdown = () => {
-    isOpen = false;
+  const handleSelect = (presetId: string | null) => {
+    if (presetId) DialStore.loadPreset(panelId, presetId);
+    else DialStore.clearActivePreset(panelId);
+    close();
+  };
+
+  const handleDelete = (e: MouseEvent, presetId: string) => {
+    e.stopPropagation();
+    DialStore.deletePreset(panelId, presetId);
   };
 
   $effect(() => {
@@ -50,48 +69,112 @@
     chevronOpacity.set(hasPresets ? 0.6 : 0.25);
   });
 
+  // Tether the floating dropdown to the trigger via Floating UI while open.
+  $effect(() => {
+    if (!isOpen || !triggerRef || !dropdownRef) return;
+    return attachDropdown(triggerRef, dropdownRef, {
+      placement: 'bottom-start',
+      matchWidth: true,
+    });
+  });
+
+  // Keep the active item scrolled into view.
+  $effect(() => {
+    if (isOpen && activeIndex >= 0) {
+      document.getElementById(optionId(activeIndex))?.scrollIntoView({ block: 'nearest' });
+    }
+  });
+
+  // Close on mousedown outside trigger + dropdown.
   $effect(() => {
     if (!isOpen || typeof window === 'undefined') return;
 
-    const handleViewportChange = () => updatePos();
     const handler = (e: MouseEvent) => {
       const target = e.target as Node;
       if (triggerRef?.contains(target) || dropdownRef?.contains(target)) return;
-      closeDropdown();
+      close();
     };
 
-    updatePos();
     document.addEventListener('mousedown', handler);
-    window.addEventListener('resize', handleViewportChange);
-    window.addEventListener('scroll', handleViewportChange, true);
-
-    return () => {
-      document.removeEventListener('mousedown', handler);
-      window.removeEventListener('resize', handleViewportChange);
-      window.removeEventListener('scroll', handleViewportChange, true);
-    };
+    return () => document.removeEventListener('mousedown', handler);
   });
 
-  const handleSelect = (presetId: string | null) => {
-    if (presetId) DialStore.loadPreset(panelId, presetId);
-    else DialStore.clearActivePreset(panelId);
-    closeDropdown();
+  const handleTriggerKeyDown = (e: KeyboardEvent) => {
+    if (!isOpen) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMenu(selectedIndex);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        openMenu(items.length - 1);
+      }
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % items.length;
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + items.length) % items.length;
+        break;
+      case 'Home':
+        e.preventDefault();
+        activeIndex = 0;
+        break;
+      case 'End':
+        e.preventDefault();
+        activeIndex = items.length - 1;
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (activeIndex >= 0) handleSelect(items[activeIndex].id);
+        break;
+      case 'Delete':
+      case 'Backspace': {
+        const target = items[activeIndex];
+        if (target?.id) {
+          e.preventDefault();
+          DialStore.deletePreset(panelId, target.id);
+          activeIndex = Math.max(0, activeIndex - 1);
+        }
+        break;
+      }
+      case 'Escape':
+        e.preventDefault();
+        close();
+        break;
+      case 'Tab':
+        close();
+        break;
+    }
   };
 
-  const handleDelete = (e: MouseEvent, presetId: string) => {
-    e.stopPropagation();
-    DialStore.deletePreset(panelId, presetId);
+  // Close when focus leaves the trigger.
+  const handleTriggerBlur = (e: FocusEvent) => {
+    const next = e.relatedTarget as Node | null;
+    if (next && dropdownRef?.contains(next)) return;
+    close();
   };
 </script>
 
 <div class="dialkit-preset-manager">
+  <!-- svelte-ignore a11y_role_supports_aria_props_implicit -->
   <button
     bind:this={triggerRef}
     class="dialkit-preset-trigger"
-    onclick={() => (isOpen ? closeDropdown() : openDropdown())}
+    onclick={() => (isOpen ? close() : openMenu(selectedIndex))}
+    onkeydown={handleTriggerKeyDown}
+    onblur={handleTriggerBlur}
     data-open={String(isOpen)}
     data-has-preset={String(!!activePreset)}
     data-disabled={String(!hasPresets)}
+    aria-haspopup="listbox"
+    aria-expanded={isOpen}
+    aria-controls={isOpen ? `${baseId}-listbox` : undefined}
+    aria-activedescendant={isOpen && activeIndex >= 0 ? optionId(activeIndex) : undefined}
   >
     <span class="dialkit-preset-label">
       {activePreset ? activePreset.name : 'Version 1'}
@@ -116,38 +199,44 @@
       {#if isOpen}
         <div
           bind:this={dropdownRef}
+          id={`${baseId}-listbox`}
           class="dialkit-root dialkit-preset-dropdown"
-          style={`position:absolute;top:${pos.top}px;left:${pos.left}px;min-width:${pos.width}px;`}
+          role="listbox"
+          style="position:fixed;top:0;left:0;"
           transition:dropdownTransition={{ above: false }}
         >
-          <div
-            class="dialkit-preset-item"
-            data-active={String(!activePresetId)}
-            onclick={() => handleSelect(null)}
-          >
-            <span class="dialkit-preset-name">Version 1</span>
-          </div>
-
-          {#each presets as preset (preset.id)}
+          {#each items as item, index (item.id ?? '__none__')}
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
             <div
+              id={optionId(index)}
               class="dialkit-preset-item"
-              data-active={String(preset.id === activePresetId)}
-              onclick={() => handleSelect(preset.id)}
+              role="option"
+              tabindex={-1}
+              aria-selected={index === selectedIndex}
+              data-active={String(index === activeIndex)}
+              data-selected={String(index === selectedIndex)}
+              onmousedown={(e) => e.preventDefault()}
+              onmouseenter={() => (activeIndex = index)}
+              onclick={() => handleSelect(item.id)}
             >
-              <span class="dialkit-preset-name">{preset.name}</span>
-              <button
-                class="dialkit-preset-delete"
-                onclick={(e) => handleDelete(e, preset.id)}
-                title="Delete preset"
-              >
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <path d={ICON_TRASH[0]} />
-                  <path d={ICON_TRASH[1]} />
-                  <path d={ICON_TRASH[2]} />
-                  <path d={ICON_TRASH[3]} />
-                  <path d={ICON_TRASH[4]} />
-                </svg>
-              </button>
+              <span class="dialkit-preset-name">{item.name}</span>
+              {#if item.id}
+                <button
+                  class="dialkit-preset-delete"
+                  onmousedown={(e) => e.preventDefault()}
+                  onclick={(e) => handleDelete(e, item.id!)}
+                  title="Delete preset"
+                  tabindex={-1}
+                >
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d={ICON_TRASH[0]} />
+                    <path d={ICON_TRASH[1]} />
+                    <path d={ICON_TRASH[2]} />
+                    <path d={ICON_TRASH[3]} />
+                    <path d={ICON_TRASH[4]} />
+                  </svg>
+                </button>
+              {/if}
             </div>
           {/each}
         </div>

--- a/src/svelte/components/SegmentedControl.svelte
+++ b/src/svelte/components/SegmentedControl.svelte
@@ -4,13 +4,15 @@
     label: string;
   }
 
-  let { options, value, onChange } = $props<{
+  let { options, value, onChange, label } = $props<{
     options: SegmentedControlOption[];
     value: string;
     onChange: (value: string) => void;
+    label?: string;
   }>();
 
   let containerRef = $state<HTMLDivElement | undefined>(undefined);
+  let buttonRefs = $state<(HTMLButtonElement | null)[]>([]);
   let hasAnimated = false;
   let pillLeft = $state<number | null>(null);
   let pillWidth = $state<number | null>(null);
@@ -36,9 +38,45 @@
     }
     return true;
   });
+
+  const activeIndex = $derived(
+    Math.max(0, options.findIndex((o: SegmentedControlOption) => o.value === value))
+  );
+
+  // Radiogroup arrow-key navigation: moving focus also moves selection,
+  // matching the WAI-ARIA radio pattern.
+  function handleKeyDown(e: KeyboardEvent, index: number) {
+    let nextIndex: number | null = null;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIndex = (index + 1) % options.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIndex = (index - 1 + options.length) % options.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = options.length - 1;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    onChange(options[nextIndex].value);
+    buttonRefs[nextIndex]?.focus();
+  }
 </script>
 
-<div class="dialkit-segmented" bind:this={containerRef}>
+<div
+  class="dialkit-segmented"
+  bind:this={containerRef}
+  role="radiogroup"
+  aria-label={label}
+>
   {#if pillLeft !== null && pillWidth !== null}
     <div
       class="dialkit-segmented-pill"
@@ -50,9 +88,15 @@
     ></div>
   {/if}
 
-  {#each options as option (option.value)}
+  {#each options as option, index (option.value)}
     <button
+      bind:this={buttonRefs[index]}
+      type="button"
+      role="radio"
+      aria-checked={value === option.value}
+      tabindex={index === activeIndex ? 0 : -1}
       onclick={() => onChange(option.value)}
+      onkeydown={(e) => handleKeyDown(e, index)}
       class="dialkit-segmented-button"
       data-active={String(value === option.value)}
     >

--- a/src/svelte/components/SelectControl.svelte
+++ b/src/svelte/components/SelectControl.svelte
@@ -2,7 +2,7 @@
   import { Spring } from 'svelte/motion';
   import Portal from '../Portal.svelte';
   import { dropdownTransition } from './transitions';
-  import { getDialKitPortalRoot, getDropdownPosition } from '../../dropdown-position';
+  import { getDialKitPortalRoot, attachDropdown } from '../../dropdown-position';
   import { ICON_CHEVRON } from '../../icons';
 
   type SelectOption = string | { value: string; label: string };
@@ -14,11 +14,14 @@
     onChange: (value: string) => void;
   }>();
 
+  const baseId = `dialkit-select-${Math.random().toString(36).slice(2, 9)}`;
+
   let isOpen = $state(false);
-  let pos = $state<{ top: number; left: number; width: number; above: boolean } | null>(null);
+  let activeIndex = $state(-1);
   let portalTarget = $state<HTMLElement | null>(null);
-  let triggerRef: HTMLButtonElement | undefined;
-  let dropdownRef: HTMLDivElement | undefined;
+  let triggerRef = $state<HTMLButtonElement | undefined>(undefined);
+  let dropdownRef = $state<HTMLDivElement | undefined>(undefined);
+  let optionRefs = $state<(HTMLButtonElement | null)[]>([]);
 
   const chevronRotation = new Spring(0, { stiffness: 0.2, damping: 0.6 });
 
@@ -30,36 +33,32 @@
     )
   );
 
-  const selectedOption = $derived(normalized.find((o: { value: string; label: string }) => o.value === value));
+  const selectedIndex = $derived(
+    normalized.findIndex((o: { value: string; label: string }) => o.value === value)
+  );
+  const selectedOption = $derived(normalized[selectedIndex]);
+  const optionId = (index: number) => `${baseId}-opt-${index}`;
 
-  const updatePos = () => {
-    if (!triggerRef || !portalTarget || typeof window === 'undefined') return;
-    const dropdownHeight = 8 + normalized.length * 36;
-    pos = getDropdownPosition(triggerRef, portalTarget, { dropdownHeight });
-  };
-
-  const openDropdown = () => {
-    updatePos();
+  const openMenu = (toIndex: number) => {
+    activeIndex = toIndex;
     isOpen = true;
+    // macOS Safari/Firefox don't focus a <button> on click, so force it —
+    // otherwise arrow keys hit the page instead of the trigger's handler.
+    triggerRef?.focus();
   };
 
   const closeDropdown = () => {
     isOpen = false;
   };
 
-  const dropdownStyle = $derived.by(() => {
-    if (!pos || typeof window === 'undefined') return '';
+  const commit = (index: number) => {
+    onChange(normalized[index].value);
+    isOpen = false;
+  };
 
-    if (pos.above) {
-      return `position:absolute;left:${pos.left}px;top:${pos.top}px;width:${pos.width}px;transform-origin:bottom;`;
-    }
-
-    return `position:absolute;left:${pos.left}px;top:${pos.top}px;width:${pos.width}px;transform-origin:top;`;
-  });
-
+  // Resolve portal target (closest .dialkit-root) so theme vars apply.
   $effect(() => {
     if (typeof document === 'undefined' || !triggerRef) return;
-
     portalTarget = getDialKitPortalRoot(triggerRef) ?? document.body;
   });
 
@@ -67,10 +66,27 @@
     chevronRotation.set(isOpen ? 180 : 0);
   });
 
+  // Tether the floating dropdown to the trigger via Floating UI while open.
+  $effect(() => {
+    if (!isOpen || !triggerRef || !dropdownRef) return;
+    return attachDropdown(triggerRef, dropdownRef, {
+      placement: 'bottom-start',
+      matchWidth: true,
+    });
+  });
+
+  // Focus never leaves the trigger — the active option is tracked with
+  // aria-activedescendant. Keep the active option scrolled into view.
+  $effect(() => {
+    if (isOpen && activeIndex >= 0) {
+      optionRefs[activeIndex]?.scrollIntoView({ block: 'nearest' });
+    }
+  });
+
+  // Close on click outside (covers clicks on non-focusable areas that don't
+  // blur the trigger).
   $effect(() => {
     if (!isOpen || typeof window === 'undefined') return;
-
-    const handleViewportChange = () => updatePos();
 
     const handleClick = (e: MouseEvent) => {
       const target = e.target as Node;
@@ -78,25 +94,74 @@
       closeDropdown();
     };
 
-    updatePos();
     document.addEventListener('mousedown', handleClick);
-    window.addEventListener('resize', handleViewportChange);
-    window.addEventListener('scroll', handleViewportChange, true);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClick);
-      window.removeEventListener('resize', handleViewportChange);
-      window.removeEventListener('scroll', handleViewportChange, true);
-    };
+    return () => document.removeEventListener('mousedown', handleClick);
   });
+
+  const handleTriggerKeyDown = (e: KeyboardEvent) => {
+    if (!isOpen) {
+      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openMenu(selectedIndex >= 0 ? selectedIndex : 0);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        openMenu(selectedIndex >= 0 ? selectedIndex : normalized.length - 1);
+      }
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        activeIndex = (activeIndex + 1) % normalized.length;
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        activeIndex = (activeIndex - 1 + normalized.length) % normalized.length;
+        break;
+      case 'Home':
+        e.preventDefault();
+        activeIndex = 0;
+        break;
+      case 'End':
+        e.preventDefault();
+        activeIndex = normalized.length - 1;
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (activeIndex >= 0) commit(activeIndex);
+        break;
+      case 'Escape':
+        e.preventDefault();
+        closeDropdown();
+        break;
+      case 'Tab':
+        closeDropdown();
+        break;
+    }
+  };
+
+  // Close when focus leaves the trigger (Tab away, or focus moves elsewhere).
+  const handleTriggerBlur = (e: FocusEvent) => {
+    const next = e.relatedTarget as Node | null;
+    if (next && dropdownRef?.contains(next)) return;
+    closeDropdown();
+  };
 </script>
 
 <div class="dialkit-select-row">
+  <!-- svelte-ignore a11y_role_supports_aria_props_implicit -->
   <button
     bind:this={triggerRef}
     class="dialkit-select-trigger"
-    onclick={() => (isOpen ? closeDropdown() : openDropdown())}
+    onclick={() => (isOpen ? closeDropdown() : openMenu(selectedIndex >= 0 ? selectedIndex : 0))}
+    onkeydown={handleTriggerKeyDown}
+    onblur={handleTriggerBlur}
     data-open={String(isOpen)}
+    aria-haspopup="listbox"
+    aria-expanded={isOpen}
+    aria-controls={isOpen ? `${baseId}-listbox` : undefined}
+    aria-activedescendant={isOpen && activeIndex >= 0 ? optionId(activeIndex) : undefined}
   >
     <span class="dialkit-select-label">{label}</span>
     <div class="dialkit-select-right">
@@ -118,21 +183,29 @@
 
   {#if portalTarget}
     <Portal target={portalTarget}>
-      {#if isOpen && pos}
+      {#if isOpen}
         <div
           bind:this={dropdownRef}
+          id={`${baseId}-listbox`}
           class="dialkit-select-dropdown"
-          style={dropdownStyle}
-          transition:dropdownTransition={{ above: pos.above }}
+          role="listbox"
+          style="position:fixed;top:0;left:0;"
+          transition:dropdownTransition={{ above: false }}
         >
-          {#each normalized as option (option.value)}
+          {#each normalized as option, index (option.value)}
             <button
+              bind:this={optionRefs[index]}
+              id={optionId(index)}
+              type="button"
               class="dialkit-select-option"
+              role="option"
+              aria-selected={option.value === value}
+              tabindex={-1}
               data-selected={String(option.value === value)}
-              onclick={() => {
-                onChange(option.value);
-                closeDropdown();
-              }}
+              data-active={String(index === activeIndex)}
+              onmousedown={(e) => e.preventDefault()}
+              onclick={() => commit(index)}
+              onmouseenter={() => (activeIndex = index)}
             >
               {option.label}
             </button>

--- a/src/svelte/components/ShortcutsMenu.svelte
+++ b/src/svelte/components/ShortcutsMenu.svelte
@@ -2,13 +2,13 @@
   import { DialStore } from 'dialkit/store';
   import type { ShortcutConfig } from 'dialkit/store';
   import Portal from '../Portal.svelte';
+  import { attachDropdown } from '../../dropdown-position';
 
   let { panelId } = $props<{ panelId: string }>();
 
   let isOpen = $state(false);
-  let triggerEl: HTMLButtonElement | undefined;
-  let dropdownEl: HTMLDivElement | undefined;
-  let pos = $state({ top: 0, right: 0 });
+  let triggerEl = $state<HTMLButtonElement | undefined>(undefined);
+  let dropdownEl = $state<HTMLDivElement | undefined>(undefined);
 
   function formatShortcutKey(sc: ShortcutConfig): string {
     if (!sc.key) return '\u2014';
@@ -30,10 +30,6 @@
   }
 
   function open() {
-    const rect = triggerEl?.getBoundingClientRect();
-    if (rect) {
-      pos = { top: rect.bottom + 4, right: window.innerWidth - rect.right };
-    }
     isOpen = true;
   }
 
@@ -45,6 +41,12 @@
     if (isOpen) close();
     else open();
   }
+
+  // Tether the floating dropdown to the trigger via Floating UI while open.
+  $effect(() => {
+    if (!isOpen || !triggerEl || !dropdownEl) return;
+    return attachDropdown(triggerEl, dropdownEl, { placement: 'bottom-end' });
+  });
 
   // Close on mousedown outside
   $effect(() => {
@@ -105,9 +107,7 @@
       <div
         bind:this={dropdownEl}
         class="dialkit-root dialkit-shortcuts-dropdown"
-        style:position="fixed"
-        style:top="{pos.top}px"
-        style:right="{pos.right}px"
+        style="position:fixed;top:0;left:0;"
       >
         <div class="dialkit-shortcuts-title">Keyboard Shortcuts</div>
         <div class="dialkit-shortcuts-list">

--- a/src/svelte/components/Slider.svelte
+++ b/src/svelte/components/Slider.svelte
@@ -11,6 +11,7 @@
     min = 0,
     max = 1,
     step = 0.01,
+    unit,
     shortcut,
     shortcutActive = false,
   } = $props<{
@@ -41,6 +42,7 @@
   let isInteracting = $state(false);
   let isDragging = $state(false);
   let isHovered = $state(false);
+  let isFocused = $state(false);
   let isValueHovered = $state(false);
   let isValueEditable = $state(false);
   let showInput = $state(false);
@@ -116,7 +118,7 @@
   });
 
   const percentage = $derived(((value - min) / (max - min)) * 100);
-  const isActive = $derived(isInteracting || isHovered);
+  const isActive = $derived(isInteracting || isHovered || isFocused);
 
   const leftThreshold = $derived.by(() => {
     const trackWidth = wrapperRef?.offsetWidth;
@@ -260,6 +262,38 @@
     inputValue = value.toFixed(decimalsForStep(step));
   };
 
+  const handleTrackKeyDown = (e: KeyboardEvent) => {
+    let next: number;
+    const bigStep = step * 10;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        next = value + step;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        next = value - step;
+        break;
+      case 'PageUp':
+        next = value + bigStep;
+        break;
+      case 'PageDown':
+        next = value - bigStep;
+        break;
+      case 'Home':
+        next = min;
+        break;
+      case 'End':
+        next = max;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    const clamped = Math.max(min, Math.min(max, next));
+    onChange(roundValue(clamped, step));
+  };
+
   const displayValue = $derived(value.toFixed(decimalsForStep(step)));
 
   const trackStyle = $derived(`width:calc(100% + ${Math.abs(rubberStretchPx.current)}px);transform:translateX(${rubberStretchPx.current < 0 ? rubberStretchPx.current : 0}px);`);
@@ -277,6 +311,16 @@
     onpointercancel={handlePointerCancel}
     onmouseenter={() => (isHovered = true)}
     onmouseleave={() => (isHovered = false)}
+    onkeydown={handleTrackKeyDown}
+    onfocus={() => (isFocused = true)}
+    onblur={() => (isFocused = false)}
+    tabindex={showInput ? -1 : 0}
+    role="slider"
+    aria-label={label}
+    aria-valuemin={min}
+    aria-valuemax={max}
+    aria-valuenow={value}
+    aria-valuetext={unit ? `${displayValue}${unit}` : displayValue}
   >
     <div class="dialkit-slider-hashmarks">
       {#each hashMarks as mark (mark.key)}

--- a/src/vue/components/Folder.ts
+++ b/src/vue/components/Folder.ts
@@ -45,6 +45,13 @@ export const Folder = defineComponent({
       emit('openChange', next);
     };
 
+    const handleToggleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        handleToggle();
+      }
+    };
+
     let ro: ResizeObserver | null = null;
 
     onMounted(() => {
@@ -72,9 +79,18 @@ export const Folder = defineComponent({
       ro?.disconnect();
     });
 
-    const renderHeader = () => h('div', {
+    const renderHeader = () => {
+      // The header toggles the folder. For a root panel it's only interactive
+      // while open (collapsing it); the collapsed circle handles re-opening.
+      const headerInteractive = props.isRoot ? isOpen.value && !props.inline : true;
+      return h('div', {
       class: `dialkit-folder-header ${props.isRoot ? 'dialkit-panel-header' : ''}`,
       onClick: handleToggle,
+      role: headerInteractive ? 'button' : undefined,
+      tabindex: headerInteractive ? 0 : undefined,
+      'aria-expanded': headerInteractive ? isOpen.value : undefined,
+      'aria-label': headerInteractive ? props.title : undefined,
+      onKeydown: headerInteractive ? handleToggleKeyDown : undefined,
     }, [
       h('div', { class: 'dialkit-folder-header-top' }, [
         props.isRoot
@@ -115,6 +131,7 @@ export const Folder = defineComponent({
         ? h('div', { class: 'dialkit-panel-toolbar', onClick: (event: Event) => event.stopPropagation() }, [props.toolbar()])
         : null,
     ]);
+    };
 
     const renderChildren = () => h('div', { class: 'dialkit-folder-inner' }, slots.default ? slots.default() : []);
 
@@ -177,6 +194,11 @@ export const Folder = defineComponent({
           class: 'dialkit-panel-inner',
           style: panelStyle,
           onClick: !isOpen.value ? handleToggle : undefined,
+          role: !isOpen.value ? 'button' : undefined,
+          tabindex: !isOpen.value ? 0 : undefined,
+          'aria-expanded': !isOpen.value ? false : undefined,
+          'aria-label': !isOpen.value ? props.title : undefined,
+          onKeydown: !isOpen.value ? handleToggleKeyDown : undefined,
           'data-collapsed': String(isCollapsed.value),
           whilePress: !isOpen.value ? { scale: 0.9 } : undefined,
           transition: { type: 'spring', visualDuration: 0.15, bounce: 0.3 },

--- a/src/vue/components/PresetManager.ts
+++ b/src/vue/components/PresetManager.ts
@@ -3,6 +3,9 @@ import { AnimatePresence, motion } from 'motion-v';
 import { ICON_CHEVRON, ICON_TRASH } from '../../icons';
 import { DialStore } from '../../store/DialStore';
 import type { Preset } from '../../store/DialStore';
+import { useFloatingDropdown } from '../useFloatingDropdown';
+
+let uid = 0;
 
 export const PresetManager = defineComponent({
   name: 'DialKitPresetManager',
@@ -20,25 +23,59 @@ export const PresetManager = defineComponent({
   },
   setup(props) {
     const isOpen = ref(false);
-    const pos = ref({ top: 0, left: 0, width: 0 });
+    const activeIndex = ref(-1);
 
     const triggerRef = ref<HTMLElement | null>(null);
     const dropdownRef = ref<HTMLElement | null>(null);
 
+    const baseId = `dialkit-preset-${uid++}`;
+    const listboxId = `${baseId}-listbox`;
+    const optionId = (index: number) => `${baseId}-opt-${index}`;
+
     const hasPresets = () => props.presets.length > 0;
     const activePreset = () => props.presets.find((preset) => preset.id === props.activePresetId);
 
-    const open = () => {
-      if (!hasPresets()) return;
-      const rect = triggerRef.value?.getBoundingClientRect();
-      if (rect) {
-        pos.value = { top: rect.bottom + 4, left: rect.left, width: rect.width };
-      }
-      isOpen.value = true;
-    };
+    // Flat selectable list: the implicit "Version 1" plus each preset.
+    const items = (): { id: string | null; name: string }[] => [
+      { id: null, name: 'Version 1' },
+      ...props.presets.map((p) => ({ id: p.id, name: p.name })),
+    ];
+    const selectedIndex = () => Math.max(0, items().findIndex((it) => it.id === props.activePresetId));
+
+    useFloatingDropdown(isOpen, triggerRef, dropdownRef, {
+      placement: 'bottom-start',
+      matchWidth: true,
+    });
 
     const close = () => {
       isOpen.value = false;
+    };
+
+    const openMenu = (toIndex: number) => {
+      if (!hasPresets()) return;
+      activeIndex.value = toIndex;
+      isOpen.value = true;
+      // macOS Safari/Firefox don't focus a <button> on click — force it.
+      triggerRef.value?.focus();
+    };
+
+    const toggle = () => {
+      if (isOpen.value) close();
+      else openMenu(selectedIndex());
+    };
+
+    const handleSelect = (presetId: string | null) => {
+      if (presetId) {
+        DialStore.loadPreset(props.panelId, presetId);
+      } else {
+        DialStore.clearActivePreset(props.panelId);
+      }
+      close();
+    };
+
+    const handleDelete = (event: MouseEvent, presetId: string) => {
+      event.stopPropagation();
+      DialStore.deletePreset(props.panelId, presetId);
     };
 
     const setDropdownRef = (node: unknown) => {
@@ -56,11 +93,75 @@ export const PresetManager = defineComponent({
       dropdownRef.value = null;
     };
 
-    const toggle = () => {
-      if (isOpen.value) close();
-      else open();
+    // Keep the active item scrolled into view.
+    watch([isOpen, activeIndex], () => {
+      if (isOpen.value && activeIndex.value >= 0) {
+        document.getElementById(optionId(activeIndex.value))?.scrollIntoView({ block: 'nearest' });
+      }
+    }, { flush: 'post' });
+
+    const handleTriggerKeyDown = (e: KeyboardEvent) => {
+      const list = items();
+      if (!isOpen.value) {
+        if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          openMenu(selectedIndex());
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          openMenu(list.length - 1);
+        }
+        return;
+      }
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          activeIndex.value = (activeIndex.value + 1) % list.length;
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          activeIndex.value = (activeIndex.value - 1 + list.length) % list.length;
+          break;
+        case 'Home':
+          e.preventDefault();
+          activeIndex.value = 0;
+          break;
+        case 'End':
+          e.preventDefault();
+          activeIndex.value = list.length - 1;
+          break;
+        case 'Enter':
+        case ' ':
+          e.preventDefault();
+          if (activeIndex.value >= 0) handleSelect(list[activeIndex.value].id);
+          break;
+        case 'Delete':
+        case 'Backspace': {
+          const target = list[activeIndex.value];
+          if (target?.id) {
+            e.preventDefault();
+            DialStore.deletePreset(props.panelId, target.id);
+            activeIndex.value = Math.max(0, activeIndex.value - 1);
+          }
+          break;
+        }
+        case 'Escape':
+          e.preventDefault();
+          close();
+          break;
+        case 'Tab':
+          close();
+          break;
+      }
     };
 
+    // Close when focus leaves the trigger.
+    const handleTriggerBlur = (e: FocusEvent) => {
+      const next = e.relatedTarget as Node | null;
+      if (dropdownRef.value?.contains(next)) return;
+      close();
+    };
+
+    // Close on mousedown outside trigger + dropdown.
     watch(isOpen, (open, _, onCleanup) => {
       if (!open) return;
 
@@ -76,28 +177,20 @@ export const PresetManager = defineComponent({
       });
     });
 
-    const handleSelect = (presetId: string | null) => {
-      if (presetId) {
-        DialStore.loadPreset(props.panelId, presetId);
-      } else {
-        DialStore.clearActivePreset(props.panelId);
-      }
-      close();
-    };
-
-    const handleDelete = (event: MouseEvent, presetId: string) => {
-      event.stopPropagation();
-      DialStore.deletePreset(props.panelId, presetId);
-    };
-
     return () => h('div', { class: 'dialkit-preset-manager' }, [
       h('button', {
         ref: triggerRef,
         class: 'dialkit-preset-trigger',
-        onClick: toggle,
         'data-open': String(isOpen.value),
         'data-has-preset': String(!!activePreset()),
         'data-disabled': String(!hasPresets()),
+        'aria-haspopup': 'listbox',
+        'aria-expanded': isOpen.value,
+        'aria-controls': isOpen.value ? listboxId : undefined,
+        'aria-activedescendant': isOpen.value && activeIndex.value >= 0 ? optionId(activeIndex.value) : undefined,
+        onClick: toggle,
+        onKeydown: handleTriggerKeyDown,
+        onBlur: handleTriggerBlur,
       }, [
         h('span', { class: 'dialkit-preset-label' }, activePreset()?.name ?? 'Version 1'),
         h(motion.svg, {
@@ -119,34 +212,33 @@ export const PresetManager = defineComponent({
             ? [h(motion.div, {
               key: 'dialkit-preset-dropdown',
               ref: setDropdownRef,
+              id: listboxId,
               class: 'dialkit-root dialkit-preset-dropdown',
-              style: {
-                position: 'fixed',
-                top: `${pos.value.top}px`,
-                left: `${pos.value.left}px`,
-                minWidth: `${pos.value.width}px`,
-              },
+              role: 'listbox',
+              style: { position: 'fixed', top: 0, left: 0 },
               initial: { opacity: 0, y: 4, scale: 0.97 },
               animate: { opacity: 1, y: 0, scale: 1 },
               exit: { opacity: 0, y: 4, scale: 0.97, pointerEvents: 'none' },
               transition: { type: 'spring', visualDuration: 0.15, bounce: 0 },
+            }, items().map((item, index) => h('div', {
+              key: item.id ?? '__none__',
+              id: optionId(index),
+              class: 'dialkit-preset-item',
+              role: 'option',
+              'aria-selected': index === selectedIndex(),
+              'data-active': String(index === activeIndex.value),
+              'data-selected': String(index === selectedIndex()),
+              onMousedown: (e: MouseEvent) => e.preventDefault(),
+              onMouseenter: () => { activeIndex.value = index; },
+              onClick: () => handleSelect(item.id),
             }, [
-              h('div', {
-                class: 'dialkit-preset-item',
-                'data-active': String(!props.activePresetId),
-                onClick: () => handleSelect(null),
-              }, [h('span', { class: 'dialkit-preset-name' }, 'Version 1')]),
-
-              ...props.presets.map((preset) => h('div', {
-                key: preset.id,
-                class: 'dialkit-preset-item',
-                'data-active': String(preset.id === props.activePresetId),
-                onClick: () => handleSelect(preset.id),
-              }, [
-                h('span', { class: 'dialkit-preset-name' }, preset.name),
-                h('button', {
+              h('span', { class: 'dialkit-preset-name' }, item.name),
+              item.id
+                ? h('button', {
                   class: 'dialkit-preset-delete',
-                  onClick: (event: MouseEvent) => handleDelete(event, preset.id),
+                  tabindex: -1,
+                  onMousedown: (e: MouseEvent) => e.preventDefault(),
+                  onClick: (event: MouseEvent) => handleDelete(event, item.id as string),
                   title: 'Delete preset',
                 }, [
                   h('svg', {
@@ -157,9 +249,9 @@ export const PresetManager = defineComponent({
                     'stroke-linecap': 'round',
                     'stroke-linejoin': 'round',
                   }, ICON_TRASH.map((d) => h('path', { d }))),
-                ]),
-              ])),
-            ])]
+                ])
+                : null,
+            ])))]
             : [],
         }),
       ]),

--- a/src/vue/components/SegmentedControl.ts
+++ b/src/vue/components/SegmentedControl.ts
@@ -17,12 +17,46 @@ export const SegmentedControl = defineComponent({
       type: String,
       required: true,
     },
+    label: {
+      type: String,
+      required: false,
+      default: undefined,
+    },
   },
   emits: ['change'],
   setup(props, { emit }) {
     const containerRef = ref<HTMLElement | null>(null);
     const pillRef = ref<HTMLElement | null>(null);
     const buttonRefs = new Map<string, HTMLElement>();
+    const buttonEls: (HTMLElement | null)[] = [];
+
+    // Radiogroup arrow-key navigation: moving focus also moves selection,
+    // matching the WAI-ARIA radio pattern.
+    const handleKeyDown = (e: KeyboardEvent, index: number) => {
+      const len = props.options.length;
+      let nextIndex: number | null = null;
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          nextIndex = (index + 1) % len;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          nextIndex = (index - 1 + len) % len;
+          break;
+        case 'Home':
+          nextIndex = 0;
+          break;
+        case 'End':
+          nextIndex = len - 1;
+          break;
+        default:
+          return;
+      }
+      e.preventDefault();
+      emit('change', props.options[nextIndex].value);
+      buttonEls[nextIndex]?.focus();
+    };
 
     const pillReady = ref(false);
     let hasAnimated = false;
@@ -110,7 +144,14 @@ export const SegmentedControl = defineComponent({
       { flush: 'post' }
     );
 
-    return () => h('div', { ref: containerRef, class: 'dialkit-segmented' }, [
+    const activeIndex = () => Math.max(0, props.options.findIndex((o) => o.value === props.value));
+
+    return () => h('div', {
+      ref: containerRef,
+      class: 'dialkit-segmented',
+      role: 'radiogroup',
+      'aria-label': props.label,
+    }, [
       h('div', {
         ref: pillRef,
         class: 'dialkit-segmented-pill',
@@ -120,19 +161,29 @@ export const SegmentedControl = defineComponent({
           visibility: pillReady.value ? 'visible' : 'hidden',
         },
       }),
-      ...props.options.map((option) => h('button', {
-        ref: ((el: Element | null) => {
-          if (el instanceof HTMLElement) {
-            buttonRefs.set(option.value, el);
-            return;
-          }
+      ...props.options.map((option, index) => {
+        const isActive = props.value === option.value;
+        return h('button', {
+          ref: ((el: Element | null) => {
+            if (el instanceof HTMLElement) {
+              buttonRefs.set(option.value, el);
+              buttonEls[index] = el;
+              return;
+            }
 
-          buttonRefs.delete(option.value);
-        }) as any,
-        class: 'dialkit-segmented-button',
-        'data-active': String(props.value === option.value),
-        onClick: () => emit('change', option.value),
-      }, option.label)),
+            buttonRefs.delete(option.value);
+            buttonEls[index] = null;
+          }) as any,
+          type: 'button',
+          role: 'radio',
+          'aria-checked': isActive,
+          tabindex: index === activeIndex() ? 0 : -1,
+          class: 'dialkit-segmented-button',
+          'data-active': String(isActive),
+          onClick: () => emit('change', option.value),
+          onKeydown: (e: KeyboardEvent) => handleKeyDown(e, index),
+        }, option.label);
+      }),
     ]);
   },
 });

--- a/src/vue/components/SelectControl.ts
+++ b/src/vue/components/SelectControl.ts
@@ -1,8 +1,11 @@
 import { Teleport, defineComponent, h, onMounted, ref, watch, type PropType } from 'vue';
 import { AnimatePresence, motion } from 'motion-v';
-import { getDialKitPortalRoot, getDropdownPosition } from '../../dropdown-position';
+import { getDialKitPortalRoot } from '../../dropdown-position';
+import { useFloatingDropdown } from '../useFloatingDropdown';
 
 type SelectOption = string | { value: string; label: string };
+
+let uid = 0;
 
 function toTitleCase(value: string): string {
   return value.replace(/\b\w/g, (char) => char.toUpperCase());
@@ -27,28 +30,52 @@ export const SelectControl = defineComponent({
   emits: ['change'],
   setup(props, { emit }) {
     const isOpen = ref(false);
-    const pos = ref<{ top: number; left: number; width: number; above: boolean } | null>(null);
+    const activeIndex = ref(-1);
     const portalTarget = ref<HTMLElement | null>(null);
 
     const triggerRef = ref<HTMLElement | null>(null);
     const dropdownRef = ref<HTMLElement | null>(null);
 
+    const baseId = `dialkit-select-${uid++}`;
+    const listboxId = `${baseId}-listbox`;
+    const optionId = (index: number) => `${baseId}-opt-${index}`;
+
     const normalizedOptions = () => normalizeOptions(props.options);
+    const selectedIndex = () => normalizedOptions().findIndex((option) => option.value === props.value);
     const selectedLabel = () => normalizedOptions().find((option) => option.value === props.value)?.label ?? props.value;
 
-    const updatePos = () => {
-      if (!triggerRef.value || !portalTarget.value) return;
-      const dropdownHeight = 8 + normalizedOptions().length * 36;
-      pos.value = getDropdownPosition(triggerRef.value, portalTarget.value, { dropdownHeight });
-    };
+    useFloatingDropdown(isOpen, triggerRef, dropdownRef, {
+      placement: 'bottom-start',
+      matchWidth: true,
+    });
 
-    const openDropdown = () => {
-      updatePos();
+    // Focus never leaves the trigger — the active option is tracked with
+    // aria-activedescendant. Keep the active option scrolled into view.
+    watch([isOpen, activeIndex], () => {
+      if (isOpen.value && activeIndex.value >= 0) {
+        document.getElementById(optionId(activeIndex.value))?.scrollIntoView({ block: 'nearest' });
+      }
+    }, { flush: 'post' });
+
+    const openMenu = (toIndex: number) => {
+      activeIndex.value = toIndex;
       isOpen.value = true;
+      // macOS Safari/Firefox don't focus a <button> on click, so force it.
+      triggerRef.value?.focus();
     };
 
     const closeDropdown = () => {
       isOpen.value = false;
+    };
+
+    const commit = (index: number) => {
+      emit('change', normalizedOptions()[index].value);
+      isOpen.value = false;
+    };
+
+    const toggleDropdown = () => {
+      if (isOpen.value) closeDropdown();
+      else openMenu(selectedIndex() >= 0 ? selectedIndex() : 0);
     };
 
     const setDropdownRef = (node: unknown) => {
@@ -66,30 +93,70 @@ export const SelectControl = defineComponent({
       dropdownRef.value = null;
     };
 
-    const toggleDropdown = () => {
-      if (isOpen.value) closeDropdown();
-      else openDropdown();
+    const handleTriggerKeyDown = (e: KeyboardEvent) => {
+      const len = normalizedOptions().length;
+      if (!isOpen.value) {
+        if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          openMenu(selectedIndex() >= 0 ? selectedIndex() : 0);
+        } else if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          openMenu(selectedIndex() >= 0 ? selectedIndex() : len - 1);
+        }
+        return;
+      }
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          activeIndex.value = (activeIndex.value + 1) % len;
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          activeIndex.value = (activeIndex.value - 1 + len) % len;
+          break;
+        case 'Home':
+          e.preventDefault();
+          activeIndex.value = 0;
+          break;
+        case 'End':
+          e.preventDefault();
+          activeIndex.value = len - 1;
+          break;
+        case 'Enter':
+        case ' ':
+          e.preventDefault();
+          if (activeIndex.value >= 0) commit(activeIndex.value);
+          break;
+        case 'Escape':
+          e.preventDefault();
+          isOpen.value = false;
+          break;
+        case 'Tab':
+          isOpen.value = false;
+          break;
+      }
     };
 
+    // Close when focus leaves the trigger.
+    const handleTriggerBlur = (e: FocusEvent) => {
+      const next = e.relatedTarget as Node | null;
+      if (dropdownRef.value?.contains(next)) return;
+      isOpen.value = false;
+    };
+
+    // Close on click outside (covers non-focusable areas).
     watch(isOpen, (open, _, onCleanup) => {
       if (!open) return;
 
-      const handleViewportChange = () => updatePos();
       const handleDocumentClick = (event: MouseEvent) => {
         const target = event.target as Node;
         if (triggerRef.value?.contains(target) || dropdownRef.value?.contains(target)) return;
         closeDropdown();
       };
 
-      updatePos();
       document.addEventListener('mousedown', handleDocumentClick);
-      window.addEventListener('resize', handleViewportChange);
-      window.addEventListener('scroll', handleViewportChange, true);
-
       onCleanup(() => {
         document.removeEventListener('mousedown', handleDocumentClick);
-        window.removeEventListener('resize', handleViewportChange);
-        window.removeEventListener('scroll', handleViewportChange, true);
       });
     });
 
@@ -102,7 +169,13 @@ export const SelectControl = defineComponent({
         ref: triggerRef,
         class: 'dialkit-select-trigger',
         'data-open': String(isOpen.value),
+        'aria-haspopup': 'listbox',
+        'aria-expanded': isOpen.value,
+        'aria-controls': isOpen.value ? listboxId : undefined,
+        'aria-activedescendant': isOpen.value && activeIndex.value >= 0 ? optionId(activeIndex.value) : undefined,
         onClick: toggleDropdown,
+        onKeydown: handleTriggerKeyDown,
+        onBlur: handleTriggerBlur,
       }, [
         h('span', { class: 'dialkit-select-label' }, props.label),
         h('div', { class: 'dialkit-select-right' }, [
@@ -123,30 +196,31 @@ export const SelectControl = defineComponent({
       portalTarget.value
         ? h(Teleport, { to: portalTarget.value }, [
           h(AnimatePresence, null, {
-            default: () => (isOpen.value && pos.value)
+            default: () => isOpen.value
               ? [h(motion.div, {
                 key: 'dialkit-select-dropdown',
                 ref: setDropdownRef,
+                id: listboxId,
                 class: 'dialkit-select-dropdown',
-                initial: { opacity: 0, y: pos.value.above ? 8 : -8, scale: 0.95 },
-                animate: { opacity: 1, y: 0, scale: 1 },
-                exit: { opacity: 0, y: pos.value.above ? 8 : -8, scale: 0.95 },
+                role: 'listbox',
+                initial: { opacity: 0, scale: 0.95 },
+                animate: { opacity: 1, scale: 1 },
+                exit: { opacity: 0, scale: 0.95 },
                 transition: { type: 'spring', visualDuration: 0.15, bounce: 0 },
-                style: {
-                  position: 'absolute',
-                  left: `${pos.value.left}px`,
-                  top: `${pos.value.top}px`,
-                  width: `${pos.value.width}px`,
-                  transformOrigin: pos.value.above ? 'bottom' : 'top',
-                },
-              }, normalizedOptions().map((option) => h('button', {
+                style: { position: 'fixed', top: 0, left: 0 },
+              }, normalizedOptions().map((option, index) => h('button', {
                 key: option.value,
+                id: optionId(index),
+                type: 'button',
                 class: 'dialkit-select-option',
+                role: 'option',
+                'aria-selected': option.value === props.value,
+                tabindex: -1,
                 'data-selected': String(option.value === props.value),
-                onClick: () => {
-                  emit('change', option.value);
-                  closeDropdown();
-                },
+                'data-active': String(index === activeIndex.value),
+                onMousedown: (e: MouseEvent) => e.preventDefault(),
+                onClick: () => commit(index),
+                onMouseenter: () => { activeIndex.value = index; },
               }, option.label)))]
               : [],
           }),

--- a/src/vue/components/ShortcutsMenu.ts
+++ b/src/vue/components/ShortcutsMenu.ts
@@ -1,11 +1,12 @@
-import { defineComponent, h, onMounted, onUnmounted, ref, Teleport, type PropType } from 'vue';
+import { defineComponent, h, onUnmounted, ref, Teleport, type PropType } from 'vue';
 import { DialStore, ShortcutConfig } from '../../store/DialStore';
+import { useFloatingDropdown } from '../useFloatingDropdown';
 
 function formatShortcutKey(sc: ShortcutConfig): string {
-  if (!sc.key) return '\u2014';
-  const mod = sc.modifier === 'alt' ? '\u2325'
-    : sc.modifier === 'shift' ? '\u21E7'
-    : sc.modifier === 'meta' ? '\u2318'
+  if (!sc.key) return '—';
+  const mod = sc.modifier === 'alt' ? '⌥'
+    : sc.modifier === 'shift' ? '⇧'
+    : sc.modifier === 'meta' ? '⌘'
     : '';
   return `${mod}${sc.key.toUpperCase()}`;
 }
@@ -32,15 +33,10 @@ export const ShortcutsMenu = defineComponent({
     const isOpen = ref(false);
     const triggerRef = ref<HTMLButtonElement | null>(null);
     const dropdownRef = ref<HTMLDivElement | null>(null);
-    const pos = ref({ top: 0, right: 0 });
 
-    const open = () => {
-      const rect = triggerRef.value?.getBoundingClientRect();
-      if (rect) {
-        pos.value = { top: rect.bottom + 4, right: window.innerWidth - rect.right };
-      }
-      isOpen.value = true;
-    };
+    useFloatingDropdown(isOpen, triggerRef, dropdownRef, {
+      placement: 'bottom-end',
+    });
 
     const close = () => {
       isOpen.value = false;
@@ -48,7 +44,7 @@ export const ShortcutsMenu = defineComponent({
 
     const toggle = () => {
       if (isOpen.value) close();
-      else open();
+      else isOpen.value = true;
     };
 
     let mousedownHandler: ((e: MouseEvent) => void) | null = null;
@@ -138,8 +134,8 @@ export const ShortcutsMenu = defineComponent({
                 class: 'dialkit-root dialkit-shortcuts-dropdown',
                 style: {
                   position: 'fixed',
-                  top: `${pos.value.top}px`,
-                  right: `${pos.value.right}px`,
+                  top: 0,
+                  left: 0,
                 },
               }, [
                 h('div', { class: 'dialkit-shortcuts-title' }, 'Keyboard Shortcuts'),

--- a/src/vue/components/Slider.ts
+++ b/src/vue/components/Slider.ts
@@ -37,6 +37,7 @@ export const Slider = defineComponent({
     const isInteracting = ref(false);
     const isDragging = ref(false);
     const isHovered = ref(false);
+    const isFocused = ref(false);
     const isValueHovered = ref(false);
     const isValueEditable = ref(false);
     const showInput = ref(false);
@@ -49,7 +50,7 @@ export const Slider = defineComponent({
     const handleScaleYMv = motionValue(1);
 
     const percentage = computed(() => ((props.value - min.value) / (max.value - min.value)) * 100);
-    const isActive = computed(() => isInteracting.value || isHovered.value);
+    const isActive = computed(() => isInteracting.value || isHovered.value || isFocused.value);
     const displayValue = computed(() => props.value.toFixed(decimalsForStep(step.value)));
     let pointerDownPos: { x: number; y: number } | null = null;
     let isClickFlag = true;
@@ -274,13 +275,45 @@ export const Slider = defineComponent({
       }
     };
 
+    const handleTrackKeyDown = (event: KeyboardEvent) => {
+      let next: number | null = null;
+      const bigStep = step.value * 10;
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowUp':
+          next = props.value + step.value;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          next = props.value - step.value;
+          break;
+        case 'PageUp':
+          next = props.value + bigStep;
+          break;
+        case 'PageDown':
+          next = props.value - bigStep;
+          break;
+        case 'Home':
+          next = min.value;
+          break;
+        case 'End':
+          next = max.value;
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+      const clamped = Math.max(min.value, Math.min(max.value, next));
+      emit('change', roundValue(clamped, step.value));
+    };
+
     watch(() => props.value, () => {
       if (!isInteracting.value && !snapAnim) {
         fillPercent.jump(percentage.value);
       }
     });
 
-    watch([isInteracting, isHovered, isDragging, () => props.value], () => {
+    watch([isInteracting, isHovered, isDragging, isFocused, () => props.value], () => {
       animateHandleState();
     });
 
@@ -376,6 +409,20 @@ export const Slider = defineComponent({
           isHovered.value = false;
           animateHandleState();
         },
+        onKeydown: handleTrackKeyDown,
+        onFocus: () => {
+          isFocused.value = true;
+        },
+        onBlur: () => {
+          isFocused.value = false;
+        },
+        tabindex: showInput.value ? -1 : 0,
+        role: 'slider',
+        'aria-label': props.label,
+        'aria-valuemin': min.value,
+        'aria-valuemax': max.value,
+        'aria-valuenow': props.value,
+        'aria-valuetext': props.unit ? `${displayValue.value}${props.unit}` : displayValue.value,
       }, [
         h('div', { class: 'dialkit-slider-hashmarks' }, hashMarks.value),
         h('div', {

--- a/src/vue/useFloatingDropdown.ts
+++ b/src/vue/useFloatingDropdown.ts
@@ -1,0 +1,34 @@
+import { watch, onBeforeUnmount, type Ref } from 'vue';
+import { attachDropdown, type AttachDropdownOptions } from '../dropdown-position';
+
+/**
+ * Tethers a floating dropdown to a trigger via Floating UI while `isOpen`.
+ * While the dropdown is open and both trigger + floating exist, calls
+ * attachDropdown and stores the returned cleanup; runs cleanup on close and
+ * on unmount. Positioning stays glued through scroll/resize/layout shifts.
+ */
+export function useFloatingDropdown(
+  isOpen: Ref<boolean>,
+  triggerRef: Ref<HTMLElement | null>,
+  floatingRef: Ref<HTMLElement | null>,
+  options: AttachDropdownOptions = {}
+) {
+  let cleanup: (() => void) | null = null;
+
+  const detach = () => {
+    cleanup?.();
+    cleanup = null;
+  };
+
+  const attach = () => {
+    detach();
+    if (isOpen.value && triggerRef.value && floatingRef.value) {
+      cleanup = attachDropdown(triggerRef.value, floatingRef.value, options);
+    }
+  };
+
+  // React to open state and to the floating element mounting/unmounting.
+  watch([isOpen, floatingRef], () => attach(), { flush: 'post' });
+
+  onBeforeUnmount(detach);
+}


### PR DESCRIPTION
> [!NOTE]
> Heads up — this is a **massive PR** (all four frameworks in one go). Happy to split it into smaller, easier-to-review pieces if you'd prefer (e.g. shared CSS + Folder/Slider keyboard first, then the dropdown/radio/listbox work).

## Context / motivation

While building [foldgradient.mattrothenberg.com](https://foldgradient.mattrothenberg.com/) (React), I noticed Dialkit's panel wasn't keyboard-navigable and had no visible focus indicators — you couldn't Tab or arrow through the controls. This PR fixes that, and ports the same fixes to the other frameworks for parity.

## Demo

https://github.com/user-attachments/assets/d6e52b1b-48a0-4de0-8f9c-f0758e68b3b1

## What changed

| Area | Fix |
|---|---|
| Focus rings | Added `:focus-visible` rings (shared `theme.css`) that follow each element's border-radius; inset so the panel's scroll clipping never cuts them. Text inputs get a row ring / accent underline instead of a pill. |
| Folder headers | Were `<div onClick>` — now keyboard-operable (`role="button"`, `tabIndex`, `aria-expanded`, Enter/Space). |
| Sliders | Added arrow-key control (←/→/↑/↓ by step, PageUp/Down ×10, Home/End) with `role="slider"` + ARIA value attributes. |
| Segmented control | Converted to a WAI-ARIA radio group (`role="radiogroup"`/`radio`, roving tabindex, arrow-key nav). |
| Select & version dropdowns | Rebuilt on [Floating UI](https://floating-ui.com/) (`@floating-ui/dom`) — `autoUpdate` keeps them glued through scroll/resize, with flip/shift. Added listbox keyboard nav (arrows/Home/End/Enter/Esc, `aria-activedescendant`, blur-to-close). |
| Panel drag | Guarded `setPointerCapture`/`releasePointerCapture` against an uncaught `NotFoundError`. |

**New dependency:** `@floating-ui/dom` (added to `dependencies`; replaces the hand-rolled positioning, shared across all four frameworks).

## Testing

- I only hit this — and manually verified the fix — in **React**, in the foldgradient app / the example app (select + version keyboard nav, dropdown scroll-follow, focus rings, folder/slider keys).
- The **Solid / Vue / Svelte** ports mirror the React logic and are typecheck- and build-clean (`npm run build` → `0 errors`), but I have **not** exercised them in a running app. Extra eyes / testing on those three are very welcome.

## Out of scope / notes

- A `ref is not a prop` console warning comes from `framer-motion`'s `AnimatePresence` reading `element.ref` under React 18.3 — pre-existing and unrelated to these changes.
- Pre-existing Svelte a11y-lint warnings remain on `Panel.svelte`/`DialRoot.svelte` drag handles (not touched here).
