### PR TITLE
fix: return a stable array reference from DialStore.getPanels()

### DIFF
--- a/src/store/DialStore.ts
+++ b/src/store/DialStore.ts
@@ -284,6 +284,7 @@ function getFirstOptionValue(options: (string | { value: string; label: string }
 
 class DialStoreClass {
   private panels: Map<string, PanelConfig> = new Map();
+  private panelsSnapshot: PanelConfig[] = [];
   private listeners: Map<string, Set<Listener>> = new Map();
   private globalListeners: Set<Listener> = new Set();
   private snapshots: Map<string, Record<string, DialValue>> = new Map();
@@ -496,7 +497,10 @@ class DialStoreClass {
   }
 
   getPanels(): PanelConfig[] {
-    return Array.from(this.panels.values());
+    // Stable reference between global notifications: getSnapshot-style
+    // consumers (React useSyncExternalStore, Solid `from`) compare by
+    // identity, and a fresh array on every call makes them loop or re-render.
+    return this.panelsSnapshot;
   }
 
   getPanel(id: string): PanelConfig | undefined {
@@ -787,6 +791,7 @@ class DialStoreClass {
   }
 
   private notifyGlobal(): void {
+    this.panelsSnapshot = Array.from(this.panels.values());
     this.globalListeners.forEach(fn => fn());
   }
 


### PR DESCRIPTION
## Summary

`getPanels()` builds a fresh array on every call, so getSnapshot-style consumers that compare by identity always see a "new" value:

- In React, `useSyncExternalStore(DialStore.subscribeGlobal, DialStore.getPanels)` warns "The result of getSnapshot should be cached" and can loop, since every render produces a new snapshot reference.
- Adapters that re-render on reference change do extra work even when the panel list is unchanged.

This caches the array and refreshes it in `notifyGlobal()`, which all three mutation paths (register/update/unregister) already funnel through, so callers get the same reference until the panel list actually changes.

## Test plan

- [x] `npm run typecheck` (all four framework configs) passes
- [x] `npm run build` passes
- [x] Exercised via a headless-browser smoke test of the Solid adapter (panel registration, value updates, unregister)

_Found while using dialkit in production for a while — happy to adjust anything to taste. A few more small fixes coming as separate PRs._

Made with [Cursor](https://cursor.com)