### PR TITLE
fix(solid): SegmentedControl pill position on resize and first paint

### DIFF
--- a/src/solid/components/SegmentedControl.tsx
+++ b/src/solid/components/SegmentedControl.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, For, Show } from 'solid-js';
+import { createSignal, createEffect, on, onMount, onCleanup, For, Show } from 'solid-js';
 
 interface SegmentedControlOption<T extends string> {
   value: T;
@@ -13,8 +13,9 @@ interface SegmentedControlProps<T extends string> {
 
 export function SegmentedControl<T extends string>(props: SegmentedControlProps<T>) {
   let containerRef: HTMLDivElement | undefined;
-  let hasAnimated = false;
   const [pillStyle, setPillStyle] = createSignal<{ left: number; width: number } | null>(null);
+  // The pill jumps into place on first paint, then animates on value changes.
+  const [hasChanged, setHasChanged] = createSignal(false);
 
   const measure = () => {
     if (!containerRef) return;
@@ -26,20 +27,23 @@ export function SegmentedControl<T extends string>(props: SegmentedControlProps<
     });
   };
 
-  createEffect(() => {
-    void props.value;
-    void props.options.length;
-    measure();
+  createEffect(on(() => [props.value, props.options.length] as const, measure));
+
+  createEffect(on(() => props.value, () => setHasChanged(true), { defer: true }));
+
+  // Keep the pill aligned when the container itself resizes (e.g. panel width).
+  onMount(() => {
+    if (!containerRef) return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(containerRef);
+    onCleanup(() => ro.disconnect());
   });
 
-  const transition = (): string => {
-    void props.value;
-    if (!hasAnimated) {
-      hasAnimated = true;
-      return 'none';
-    }
-    return 'left 0.2s cubic-bezier(0.25, 1, 0.5, 1), width 0.2s cubic-bezier(0.25, 1, 0.5, 1)';
-  };
+  const transition = () => (
+    hasChanged()
+      ? 'left 0.2s cubic-bezier(0.25, 1, 0.5, 1), width 0.2s cubic-bezier(0.25, 1, 0.5, 1)'
+      : 'none'
+  );
 
   return (
     <div class="dialkit-segmented" ref={containerRef}>


### PR DESCRIPTION
## Summary

Two fixes to the sliding pill in the Solid `SegmentedControl`:

- The pill was only measured when `value`/`options` changed, so container resizes (panel width changes, window resize, fonts loading) left it misaligned until the next value change. A `ResizeObserver` on the container now re-measures on size changes.
- The slide transition ran on first paint, so the pill visibly animated into place on mount. The component now tracks whether the value has actually changed (deferred `on(value)`) and renders with `transition: none` until then.

The React/Vue/Svelte variants have the same resize-measurement gap — happy to port this there too if you'd like.

## Test plan

- [x] `npm run typecheck` (all four framework configs) passes
- [x] `npm run build` passes
- [x] Headless-browser smoke test: toggled a segmented control (Off/On) and verified the bound value and pill position update

Made with [Cursor](https://cursor.com)