### PR TITLE
feat(solid): fine-grained dial values via createStore + reconcile

### DIFF
--- a/src/solid/createDialKit.ts
+++ b/src/solid/createDialKit.ts
@@ -1,4 +1,6 @@
-import { createSignal, createMemo, onMount, onCleanup, createUniqueId, type Accessor } from 'solid-js';
+import { onMount, onCleanup, createUniqueId, type Accessor } from 'solid-js';
+import { isServer } from 'solid-js/web';
+import { createStore, reconcile } from 'solid-js/store';
 import { DialStore, flattenDialValueUpdates, resolveDialValues } from '../store/DialStore';
 import type {
   DialConfig,
@@ -41,19 +43,26 @@ export function createDialKitController<T extends DialConfig>(
   const hasStableId = options?.id !== undefined;
   const panelId = options?.id ?? `${name}-${id}`;
 
-  const [flatValues, setFlatValues] = createSignal<Record<string, DialValue>>(
-    DialStore.getValues(panelId)
+  // Resolved values live in a store so consumers reading `values().someKey`
+  // subscribe to that key alone; reconcile diffs each snapshot from the
+  // external DialStore instead of replacing the whole object.
+  const [values, setValues] = createStore(
+    resolveDialValues(config, DialStore.getValues(panelId))
   );
+
+  if (!isServer) {
+    // Subscribe at setup so the notify fired by registerPanel (in onMount)
+    // syncs persisted/preset values into the store without a manual copy.
+    const unsubValues = DialStore.subscribe(panelId, () => {
+      setValues(reconcile(resolveDialValues(config, DialStore.getValues(panelId))));
+    });
+    onCleanup(unsubValues);
+  }
 
   onMount(() => {
     DialStore.registerPanel(panelId, name, config, options?.shortcuts, {
       retainOnUnmount: hasStableId,
       persist: options?.persist,
-    });
-    setFlatValues(DialStore.getValues(panelId));
-
-    const unsubValues = DialStore.subscribe(panelId, () => {
-      setFlatValues(DialStore.getValues(panelId));
     });
 
     const unsubActions = options?.onAction
@@ -61,16 +70,13 @@ export function createDialKitController<T extends DialConfig>(
       : undefined;
 
     onCleanup(() => {
-      unsubValues();
       unsubActions?.();
       DialStore.unregisterPanel(panelId);
     });
   });
 
-  const values = createMemo(() => resolveDialValues(config, flatValues()));
-
   return {
-    values,
+    values: () => values,
     setValue(path, value) {
       DialStore.updateValue(panelId, path, value);
     },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -63,7 +63,7 @@ export default defineConfig([
     },
     splitting: false,
     sourcemap: true,
-    external: ['solid-js', 'solid-js/web', 'motion'],
+    external: ['solid-js', 'solid-js/web', 'solid-js/store', 'motion'],
     tsconfig: 'tsconfig.solid.json',
     esbuildPlugins: [solidPlugin()],
   },


### PR DESCRIPTION
## Summary

`createDialKit` kept the whole resolved-values object in one signal (`createSignal` + `createMemo`), so every dial change re-ran every consumer that read *any* value. This holds the resolved values in a `solid-js/store` proxy and `reconcile()`s each DialStore snapshot into it: consumers reading `values().foo` now only re-run when `foo` itself changes — which is what Solid users expect from fine-grained reactivity.

Two supporting changes:

- The store subscription happens at setup (client only, guarded by `isServer`) instead of inside `onMount`, so the notification fired by `registerPanel` itself — persisted values, presets — lands in the store without a manual copy. Cleanup is still handled by `onCleanup`.
- `solid-js/store` is marked external in tsup alongside `solid-js` / `solid-js/web`, so it resolves to the host app's copy.

The public API is unchanged: `values` is still an accessor, `values()` still returns the resolved object.

## Test plan

- [x] `npm run typecheck` (all four framework configs) passes
- [x] `npm run build` passes
- [x] Headless-browser smoke test against a Vite + Solid app: initial values resolve (including persisted-path), slider drag and toggle updates propagate to consumers

Made with [Cursor](https://cursor.com)