### PR TITLE
refactor(solid): idiomatic reactivity for the component layer

### DIFF
--- a/src/solid/components/DialRoot.tsx
+++ b/src/solid/components/DialRoot.tsx
@@ -1,9 +1,9 @@
-import { createEffect, createSignal, onCleanup, onMount, Show, For } from 'solid-js';
+import { createSignal, onMount, Show, For } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { DialStore } from '../../store/DialStore';
-import type { PanelConfig } from '../../store/DialStore';
+import { fromStore } from '../primitives';
 import { ShortcutListener } from './ShortcutListener';
-import { Folder } from './Folder';
+import { RootPanel } from './RootPanel';
 import { Panel } from './Panel';
 import {
   blockPanelDragClick,
@@ -38,8 +38,20 @@ interface DialRootProps {
 }
 
 export function DialRoot(props: DialRootProps) {
-  if ((props.productionEnabled ?? isDevDefault) === false) return null;
-  const [panels, setPanels] = createSignal<PanelConfig[]>([]);
+  const enabled = () => (props.productionEnabled ?? isDevDefault) !== false;
+  return (
+    <Show when={enabled()}>
+      <DialRootInner {...props} />
+    </Show>
+  );
+}
+
+function DialRootInner(props: DialRootProps) {
+  const panels = fromStore(
+    () => DialStore.getPanels(),
+    (notify) => DialStore.subscribeGlobal(notify)
+  );
+  // Hydration gate: server renders nothing, client's first render must match.
   const [mounted, setMounted] = createSignal(false);
   const [dragOffset, setDragOffset] = createSignal<PanelDragOffset | null>(null);
   const [activePosition, setActivePosition] = createSignal<DialPosition>(props.position ?? 'top-right');
@@ -50,58 +62,65 @@ export function DialRoot(props: DialRootProps) {
   let dragStart: PanelDragStart | null = null;
   let didDrag = false;
   let dragTarget: HTMLElement | null = null;
-  let panelOpenStates = new Map<string, boolean>();
-  let rootOpen: boolean | undefined;
 
-  onMount(() => {
-    setMounted(true);
-    setPanels(DialStore.getPanels());
-    const unsub = DialStore.subscribeGlobal(() => {
-      setPanels(DialStore.getPanels());
-    });
-    onCleanup(unsub);
-  });
+  onMount(() => setMounted(true));
 
-  createEffect(() => {
-    const fallbackOpen = inline() || (props.defaultOpen ?? true);
-    const nextStates = new Map<string, boolean>();
-    for (const panel of panels()) {
-      nextStates.set(panel.id, panelOpenStates.get(panel.id) ?? fallbackOpen);
-    }
-    panelOpenStates = nextStates;
-    rootOpen = Array.from(nextStates.values()).some(Boolean);
-  });
+  // Open state is lifted from the panels/root folder via onOpenChange
+  // callbacks (this replaces the old data-collapsed MutationObserver).
+  // Panels that have not reported yet fall back to defaultOpen.
+  const fallbackOpen = () => inline() || (props.defaultOpen ?? true);
+  const panelOpenStates = new Map<string, boolean>();
+  let rootFolderOpen: boolean | undefined;
 
-  createEffect(() => {
-    if (!mounted() || inline() || !panelRef) return;
+  const anyOpen = () => {
+    const list = panels();
+    if (list.length > 1) return rootFolderOpen ?? fallbackOpen();
+    return list.some((panel) => panelOpenStates.get(panel.id) ?? fallbackOpen());
+  };
 
-    const observer = new MutationObserver(() => {
-      const inners = panelRef?.querySelectorAll('.dialkit-panel-inner');
-      if (!inners || inners.length === 0) return;
-      const collapsed = Array.from(inners).every((el) => el.getAttribute('data-collapsed') === 'true');
-      const currentDragOffset = dragOffset();
+  // On collapse/expand: swap the drag offset between the expanded panel and
+  // the collapsed bubble so a dragged bubble returns to where it was left.
+  const applyDragOffsetForOpen = (open: boolean) => {
+    if (inline()) return;
+    const currentDragOffset = dragOffset();
 
-      if (!collapsed) {
-        if (currentDragOffset) {
-          lastDragOffset = currentDragOffset;
-          const bubbleCenterX = currentDragOffset.x + 21;
-          setActivePosition(bubbleCenterX < window.innerWidth / 2 ? 'top-left' : 'top-right');
-        } else {
-          setActivePosition(props.position ?? 'top-right');
-        }
-        setDragOffset(null);
-      } else if (currentDragOffset) {
+    if (open) {
+      if (currentDragOffset) {
         lastDragOffset = currentDragOffset;
-      } else if (lastDragOffset) {
-        setDragOffset(lastDragOffset);
+        const bubbleCenterX = currentDragOffset.x + 21;
+        setActivePosition(bubbleCenterX < window.innerWidth / 2 ? 'top-left' : 'top-right');
+      } else {
+        setActivePosition(props.position ?? 'top-right');
       }
-    });
+      setDragOffset(null);
+    } else if (currentDragOffset) {
+      lastDragOffset = currentDragOffset;
+    } else if (lastDragOffset) {
+      setDragOffset(lastDragOffset);
+    }
+  };
 
-    observer.observe(panelRef, { subtree: true, attributes: true, attributeFilter: ['data-collapsed'] });
-    onCleanup(() => observer.disconnect());
-  });
+  const reactToOpenChange = (before: boolean) => {
+    const after = anyOpen();
+    if (after === before) return;
+    applyDragOffsetForOpen(after);
+    props.onOpenChange?.(after);
+  };
+
+  const handlePanelOpenChange = (panelId: string, open: boolean) => {
+    const before = anyOpen();
+    panelOpenStates.set(panelId, open);
+    reactToOpenChange(before);
+  };
+
+  const handleRootOpenChange = (open: boolean) => {
+    const before = anyOpen();
+    rootFolderOpen = open;
+    reactToOpenChange(before);
+  };
 
   const handlePointerDown = (event: PointerEvent) => {
+    if (inline()) return;
     const panel = panelRef ?? null;
     const handle = getPanelDragHandle(event.target, panel);
     if (!panel || !handle) return;
@@ -142,24 +161,6 @@ export function DialRoot(props: DialRootProps) {
     dragTarget = null;
   };
 
-  const handlePanelOpenChange = (panelId: string, open: boolean) => {
-    panelOpenStates.set(panelId, open);
-    const fallbackOpen = inline() || (props.defaultOpen ?? true);
-    const nextRootOpen = panels().some((panel) => (
-      panelOpenStates.get(panel.id) ?? fallbackOpen
-    ));
-
-    if (rootOpen === nextRootOpen) return;
-    rootOpen = nextRootOpen;
-    props.onOpenChange?.(nextRootOpen);
-  };
-
-  const handleRootOpenChange = (open: boolean) => {
-    if (rootOpen === open) return;
-    rootOpen = open;
-    props.onOpenChange?.(open);
-  };
-
   const dragStyle = () => {
     const offset = dragOffset();
     return offset
@@ -183,10 +184,10 @@ export function DialRoot(props: DialRootProps) {
           data-mode={props.mode ?? 'popover'}
           data-multiple={panels().length > 1 ? 'true' : undefined}
           style={dragStyle()}
-          onPointerDown={!inline() ? handlePointerDown : undefined}
-          onPointerMove={!inline() ? handlePointerMove : undefined}
-          onPointerUp={!inline() ? handlePointerUp : undefined}
-          onPointerCancel={!inline() ? handlePointerUp : undefined}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerUp}
         >
           <Show
             when={panels().length > 1}
@@ -195,7 +196,7 @@ export function DialRoot(props: DialRootProps) {
                 {(panel) => (
                   <Panel
                     panel={panel}
-                    defaultOpen={inline() || (props.defaultOpen ?? true)}
+                    defaultOpen={fallbackOpen()}
                     inline={inline()}
                     onOpenChange={(open) => handlePanelOpenChange(panel.id, open)}
                   />
@@ -204,10 +205,9 @@ export function DialRoot(props: DialRootProps) {
             }
           >
             <div class="dialkit-panel-wrapper">
-              <Folder
+              <RootPanel
                 title="DialKit"
-                defaultOpen={inline() || (props.defaultOpen ?? true)}
-                isRoot={true}
+                defaultOpen={fallbackOpen()}
                 inline={inline()}
                 onOpenChange={handleRootOpenChange}
                 panelHeightOffset={2}
@@ -221,7 +221,7 @@ export function DialRoot(props: DialRootProps) {
                     />
                   )}
                 </For>
-              </Folder>
+              </RootPanel>
             </div>
           </Show>
         </div>
@@ -230,7 +230,7 @@ export function DialRoot(props: DialRootProps) {
   );
 
   return (
-    <Show when={mounted() && typeof window !== 'undefined' && panels().length > 0}>
+    <Show when={mounted() && panels().length > 0}>
       <Show when={!inline()} fallback={content()}>
         <Portal mount={document.body}>
           {content()}

--- a/src/solid/components/Folder.tsx
+++ b/src/solid/components/Folder.tsx
@@ -1,196 +1,133 @@
-import { createSignal, createEffect, onCleanup, Show, JSX } from 'solid-js';
+import { createSignal, createEffect, on, onCleanup, Show, JSX } from 'solid-js';
 import { animate } from 'motion';
-import { ICON_PANEL, ICON_CHEVRON } from '../../icons';
+import { ICON_CHEVRON } from '../../icons';
+import type { AnimationHandle } from '../primitives';
+import { RootPanel } from './RootPanel';
 
 interface FolderProps {
   title: string;
   children: JSX.Element;
   defaultOpen?: boolean;
-  isRoot?: boolean;
-  inline?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
+  /** @deprecated Use RootPanel instead; kept for backwards compatibility. */
+  isRoot?: boolean;
+  /** @deprecated Only meaningful with isRoot. */
+  inline?: boolean;
+  /** @deprecated Only meaningful with isRoot. */
   toolbar?: JSX.Element;
+  /** @deprecated Only meaningful with isRoot. */
   panelHeightOffset?: number;
 }
 
-export function Folder(props: FolderProps) {
-  const [isOpen, setIsOpen] = createSignal(props.defaultOpen ?? true);
-  const [isCollapsed, setIsCollapsed] = createSignal(!(props.defaultOpen ?? true));
-  const [contentHeight, setContentHeight] = createSignal<number | undefined>(undefined);
-  const [windowHeight, setWindowHeight] = createSignal(typeof window !== 'undefined' ? window.innerHeight : 800);
+const sectionTransition = { type: 'spring' as const, visualDuration: 0.35, bounce: 0.1 };
 
+/** Collapsible section with animated height/opacity and rotating chevron. */
+export function Folder(props: FolderProps) {
+  // Root panels are a different component; delegate for old call sites.
   if (props.isRoot) {
-    const onResize = () => setWindowHeight(window.innerHeight);
-    window.addEventListener('resize', onResize);
-    onCleanup(() => window.removeEventListener('resize', onResize));
+    return <RootPanel {...props} />;
   }
 
-  // Section content animation state
+  const [isOpen, setIsOpen] = createSignal(props.defaultOpen ?? true);
   const [contentMounted, setContentMounted] = createSignal(props.defaultOpen ?? true);
   let skipFirstAnim = props.defaultOpen ?? true;
   let sectionContentRef: HTMLDivElement | undefined;
-  let sectionAnim: any = null;
-  let folderChevronRef: SVGSVGElement | undefined;
-  let chevronAnim: any = null;
-  let chevronInitialized = false;
-  let panelTapAnim: any = null;
+  let sectionAnim: AnimationHandle | null = null;
+  let chevronRef: SVGSVGElement | undefined;
+  let chevronAnim: AnimationHandle | null = null;
 
-  let contentRef: HTMLDivElement | undefined;
-
-  // Track content height for root panel sizing
-  createEffect(() => {
-    if (!props.isRoot || !isOpen()) return;
-    const el = contentRef;
-    if (!el) return;
-    const ro = new ResizeObserver(() => {
-      const h = el.offsetHeight;
-      setContentHeight(prev => prev === h ? prev : h);
-    });
-    ro.observe(el);
-    onCleanup(() => ro.disconnect());
+  onCleanup(() => {
+    sectionAnim?.stop();
+    chevronAnim?.stop();
   });
 
-  createEffect(() => {
-    if (props.isRoot || !folderChevronRef) return;
-    const open = isOpen();
+  // Chevron renders at its resting angle; only animate on changes.
+  createEffect(on(isOpen, (open) => {
+    if (!chevronRef) return;
     chevronAnim?.stop();
-
-    if (!chevronInitialized) {
-      folderChevronRef.style.transform = `rotate(${open ? 0 : 180}deg)`;
-      chevronInitialized = true;
-      return;
-    }
-
     chevronAnim = animate(
-      folderChevronRef,
+      chevronRef,
       { rotate: open ? 0 : 180 },
       { type: 'spring', visualDuration: 0.35, bounce: 0.15 }
     );
-
-    onCleanup(() => chevronAnim?.stop());
-  });
+  }, { defer: true }));
 
   const handleToggle = () => {
-    if (props.inline && props.isRoot) return;
     const next = !isOpen();
     setIsOpen(next);
     if (next) {
-      setIsCollapsed(false);
-      if (!props.isRoot) {
-        sectionAnim?.stop();
-        sectionAnim = null;
-        if (sectionContentRef) {
-          // If close was interrupted, animate section back open.
-          sectionAnim = animate(
-            sectionContentRef,
-            { height: 'auto', opacity: 1 },
-            {
-              type: 'spring',
-              visualDuration: 0.35,
-              bounce: 0.1,
-              onComplete: () => {
-                sectionAnim = null;
-              },
-            }
-          );
-        } else {
-          // If fully unmounted, mount and let the ref callback run enter animation.
-          setContentMounted(true);
-        }
+      sectionAnim?.stop();
+      sectionAnim = null;
+      if (sectionContentRef) {
+        // If close was interrupted, animate the section back open.
+        sectionAnim = animate(
+          sectionContentRef,
+          { height: 'auto', opacity: 1 },
+          {
+            ...sectionTransition,
+            onComplete: () => {
+              sectionAnim = null;
+            },
+          }
+        );
+      } else {
+        // If fully unmounted, mount and let the ref callback run the enter animation.
+        setContentMounted(true);
       }
+    } else if (sectionContentRef) {
+      const currentHeight = sectionContentRef.getBoundingClientRect().height;
+      sectionContentRef.style.height = `${currentHeight}px`;
+      sectionAnim?.stop();
+      sectionAnim = animate(
+        sectionContentRef,
+        { height: 0, opacity: 0 },
+        {
+          ...sectionTransition,
+          onComplete: () => {
+            setContentMounted(false);
+            sectionAnim = null;
+            sectionContentRef = undefined;
+          },
+        }
+      );
     } else {
-      setIsCollapsed(true);
-      if (!props.isRoot) {
-        if (sectionContentRef) {
-          const currentHeight = sectionContentRef.getBoundingClientRect().height;
-          sectionContentRef.style.height = `${currentHeight}px`;
-          sectionAnim?.stop();
-          sectionAnim = animate(
-            sectionContentRef,
-            { height: 0, opacity: 0 },
-            {
-              type: 'spring', visualDuration: 0.35, bounce: 0.1,
-              onComplete: () => {
-                setContentMounted(false);
-                sectionAnim = null;
-                sectionContentRef = undefined;
-              },
-            }
-          );
-        } else {
-          setContentMounted(false);
-        }
-      }
+      setContentMounted(false);
     }
     props.onOpenChange?.(next);
   };
 
-  const folderContent = () => (
-    <div
-      ref={(el) => { if (props.isRoot) contentRef = el; }}
-      class={`dialkit-folder ${props.isRoot ? 'dialkit-folder-root' : ''}`}
-      data-open={String(isOpen())}
-    >
-      <div
-        class={`dialkit-folder-header ${props.isRoot ? 'dialkit-panel-header' : ''}`}
-        onClick={handleToggle}
-      >
+  return (
+    <div class="dialkit-folder" data-open={String(isOpen())}>
+      <div class="dialkit-folder-header" onClick={handleToggle}>
         <div class="dialkit-folder-header-top">
-          {props.isRoot ? (
-            <Show when={isOpen()}>
-              <div class="dialkit-folder-title-row">
-                <span class="dialkit-folder-title dialkit-folder-title-root">
-                  {props.title}
-                </span>
-              </div>
-            </Show>
-          ) : (
-            <div class="dialkit-folder-title-row">
-              <span class="dialkit-folder-title">{props.title}</span>
-            </div>
-          )}
-
-          {props.isRoot && !props.inline && (
-            <svg class="dialkit-panel-icon" viewBox="0 0 16 16" fill="none">
-              <path
-                opacity="0.5"
-                d={ICON_PANEL.path}
-                fill="currentColor"
-              />
-              <circle cx={ICON_PANEL.circles[0].cx} cy={ICON_PANEL.circles[0].cy} r={ICON_PANEL.circles[0].r} fill="currentColor" stroke="currentColor" stroke-width="1.25" />
-              <circle cx={ICON_PANEL.circles[1].cx} cy={ICON_PANEL.circles[1].cy} r={ICON_PANEL.circles[1].r} fill="currentColor" stroke="currentColor" stroke-width="1.25" />
-              <circle cx={ICON_PANEL.circles[2].cx} cy={ICON_PANEL.circles[2].cy} r={ICON_PANEL.circles[2].r} fill="currentColor" stroke="currentColor" stroke-width="1.25" />
-            </svg>
-          )}
-          {!props.isRoot && (
-            <svg
-              ref={folderChevronRef}
-              class="dialkit-folder-icon"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2.5"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-            >
-              <path d={ICON_CHEVRON} />
-            </svg>
-          )}
-        </div>
-
-        <Show when={props.isRoot && props.toolbar && isOpen()}>
-          <div class="dialkit-panel-toolbar" onClick={(e) => e.stopPropagation()}>
-            {props.toolbar}
+          <div class="dialkit-folder-title-row">
+            <span class="dialkit-folder-title">{props.title}</span>
           </div>
-        </Show>
+
+          <svg
+            ref={chevronRef}
+            class="dialkit-folder-icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            style={{ transform: `rotate(${(props.defaultOpen ?? true) ? 0 : 180}deg)` }}
+          >
+            <path d={ICON_CHEVRON} />
+          </svg>
+        </div>
       </div>
 
-      <Show when={props.isRoot ? isOpen() : contentMounted()}>
+      <Show when={contentMounted()}>
         <div
           ref={(el) => {
-            if (props.isRoot) return;
             sectionContentRef = el;
-            if (skipFirstAnim) { skipFirstAnim = false; return; }
+            if (skipFirstAnim) {
+              skipFirstAnim = false;
+              return;
+            }
 
             sectionAnim?.stop();
             el.style.height = '0px';
@@ -199,9 +136,7 @@ export function Folder(props: FolderProps) {
               el,
               { height: 'auto', opacity: 1 },
               {
-                type: 'spring',
-                visualDuration: 0.35,
-                bounce: 0.1,
+                ...sectionTransition,
                 onComplete: () => {
                   sectionAnim = null;
                 },
@@ -209,122 +144,11 @@ export function Folder(props: FolderProps) {
             );
           }}
           class="dialkit-folder-content"
-          style={!props.isRoot ? { 'clip-path': 'inset(0 -20px)' } : undefined}
+          style={{ 'clip-path': 'inset(0 -20px)' }}
         >
           <div class="dialkit-folder-inner">{props.children}</div>
         </div>
       </Show>
     </div>
   );
-
-  if (props.isRoot) {
-    if (props.inline) {
-      return (
-        <div class="dialkit-panel-inner dialkit-panel-inline">
-          {folderContent()}
-        </div>
-      );
-    }
-    let panelRef!: HTMLDivElement;
-    let rootPanelAnim: any = null;
-    let rootPanelInitialized = false;
-    let lastRootOpen = isOpen();
-
-    createEffect(() => {
-      if (!panelRef || isOpen()) return;
-      const handler = (e: Event) => {
-        e.stopPropagation();
-        handleToggle();
-      };
-      panelRef.addEventListener('click', handler);
-      onCleanup(() => panelRef.removeEventListener('click', handler));
-    });
-
-    createEffect(() => {
-      if (!panelRef) return;
-
-      const open = isOpen();
-      const measuredOpenHeight = contentHeight() !== undefined
-        ? Math.min(contentHeight()! + (props.panelHeightOffset ?? 10), windowHeight() - 32)
-        : panelRef.getBoundingClientRect().height;
-
-      const target = {
-        width: open ? 280 : 42,
-        height: open ? measuredOpenHeight : 42,
-        borderRadius: open ? 14 : 21,
-        boxShadow: open
-          ? 'var(--dial-shadow)'
-          : 'var(--dial-shadow-collapsed)',
-      };
-
-      panelRef.style.cursor = open ? '' : 'pointer';
-      panelRef.style.overflow = open ? 'hidden auto' : 'hidden';
-
-      if (!rootPanelInitialized) {
-        rootPanelInitialized = true;
-        panelRef.style.width = `${target.width}px`;
-        panelRef.style.height = `${target.height}px`;
-        panelRef.style.borderRadius = `${target.borderRadius}px`;
-        panelRef.style.boxShadow = target.boxShadow;
-        lastRootOpen = open;
-        return;
-      }
-
-      if (open !== lastRootOpen) {
-        rootPanelAnim?.stop();
-        rootPanelAnim = animate(panelRef, target, {
-          type: 'spring',
-          visualDuration: 0.15,
-          bounce: 0.3,
-          onComplete: () => {
-            rootPanelAnim = null;
-          },
-        });
-        lastRootOpen = open;
-        return;
-      }
-
-      if (open) {
-        panelRef.style.height = `${target.height}px`;
-      }
-    });
-
-    onCleanup(() => {
-      rootPanelAnim?.stop();
-      panelTapAnim?.stop();
-    });
-
-    return (
-      <div
-        ref={panelRef}
-        class="dialkit-panel-inner"
-        data-collapsed={String(isCollapsed())}
-        onPointerDown={() => {
-          if (isOpen()) return;
-          (document.activeElement as HTMLElement)?.blur?.();
-          panelTapAnim?.stop();
-          panelTapAnim = animate(panelRef, { scale: 0.9 }, { type: 'spring', visualDuration: 0.15, bounce: 0.3 });
-        }}
-        onPointerUp={() => {
-          if (isOpen()) return;
-          panelTapAnim?.stop();
-          panelTapAnim = animate(panelRef, { scale: 1 }, { type: 'spring', visualDuration: 0.15, bounce: 0.3 });
-        }}
-        onPointerCancel={() => {
-          if (isOpen()) return;
-          panelTapAnim?.stop();
-          panelTapAnim = animate(panelRef, { scale: 1 }, { type: 'spring', visualDuration: 0.15, bounce: 0.3 });
-        }}
-        onPointerLeave={() => {
-          if (isOpen()) return;
-          panelTapAnim?.stop();
-          panelTapAnim = animate(panelRef, { scale: 1 }, { type: 'spring', visualDuration: 0.15, bounce: 0.3 });
-        }}
-      >
-        {folderContent()}
-      </div>
-    );
-  }
-
-  return folderContent();
 }

--- a/src/solid/components/Panel.tsx
+++ b/src/solid/components/Panel.tsx
@@ -1,11 +1,12 @@
-import { createSignal, createEffect, onMount, onCleanup, Show, For, JSX } from 'solid-js';
+import { batch, createSignal, createEffect, on, onMount, onCleanup, For } from 'solid-js';
 import { animate } from 'motion';
 import { ICON_CLIPBOARD, ICON_CHECK, ICON_ADD_PRESET } from '../../icons';
 import { DialStore } from '../../store/DialStore';
 import type { ControlMeta, PanelConfig, SpringConfig, DialValue } from '../../store/DialStore';
+import type { AnimationHandle } from '../primitives';
 import { useShortcutContext } from './ShortcutListener';
-import { ShortcutsMenu } from './ShortcutsMenu';
 import { Folder } from './Folder';
+import { RootPanel } from './RootPanel';
 import { Slider } from './Slider';
 import { Toggle } from './Toggle';
 import { SpringControl } from './SpringControl';
@@ -24,9 +25,7 @@ interface PanelProps {
 
 export function Panel(props: PanelProps) {
   const [copied, setCopied] = createSignal(false);
-  const [isPanelOpen, setIsPanelOpen] = createSignal(props.defaultOpen ?? true);
   const shortcutCtx = useShortcutContext();
-  const hasShortcuts = () => Object.keys(props.panel.shortcuts).length > 0;
   const [values, setValues] = createSignal<Record<string, DialValue>>(
     DialStore.getValues(props.panel.id)
   );
@@ -36,37 +35,21 @@ export function Panel(props: PanelProps) {
   let copyButtonRef!: HTMLButtonElement;
   let copyClipboardIconRef!: HTMLSpanElement;
   let copyCheckIconRef!: HTMLSpanElement;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let addTapAnim: any = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let copyTapAnim: any = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let copyClipboardAnim: any = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let copyCheckAnim: any = null;
-  let didInitCopyIcons = false;
+  let addTapAnim: AnimationHandle | null = null;
+  let copyTapAnim: AnimationHandle | null = null;
+  let copyClipboardAnim: AnimationHandle | null = null;
+  let copyCheckAnim: AnimationHandle | null = null;
 
   const tapTransition = { type: 'spring' as const, visualDuration: 0.15, bounce: 0.3 };
 
   onMount(() => {
     const unsub = DialStore.subscribe(props.panel.id, () => {
-      setValues(DialStore.getValues(props.panel.id));
-      setPresets(DialStore.getPresets(props.panel.id));
-      setActivePresetId(DialStore.getActivePresetId(props.panel.id));
+      batch(() => {
+        setValues(DialStore.getValues(props.panel.id));
+        setPresets(DialStore.getPresets(props.panel.id));
+        setActivePresetId(DialStore.getActivePresetId(props.panel.id));
+      });
     });
-
-    if (copyClipboardIconRef && copyCheckIconRef) {
-      copyClipboardIconRef.style.transformOrigin = '50% 50%';
-      copyClipboardIconRef.style.opacity = '1';
-      copyClipboardIconRef.style.transform = 'scale(1)';
-      copyClipboardIconRef.style.filter = 'blur(0px)';
-      copyCheckIconRef.style.transformOrigin = '50% 50%';
-      copyCheckIconRef.style.opacity = '0';
-      copyCheckIconRef.style.transform = 'scale(0.5)';
-      copyCheckIconRef.style.filter = 'blur(4px)';
-      didInitCopyIcons = true;
-    }
-
     onCleanup(unsub);
   });
 
@@ -83,14 +66,12 @@ export function Panel(props: PanelProps) {
     setTimeout(() => setCopied(false), 1500);
   };
 
-  createEffect(() => {
-    const isCopied = copied();
+  // Icons render with their resting styles inline; only animate on changes.
+  createEffect(on(copied, (isCopied) => {
     if (!copyClipboardIconRef || !copyCheckIconRef) return;
 
     copyClipboardAnim?.stop();
     copyCheckAnim?.stop();
-
-    if (!didInitCopyIcons) return;
 
     const transition = { type: 'spring' as const, visualDuration: 0.3, bounce: 0.2 };
     copyClipboardAnim = animate(copyClipboardIconRef, {
@@ -103,7 +84,7 @@ export function Panel(props: PanelProps) {
       scale: isCopied ? 1 : 0.5,
       filter: isCopied ? 'blur(0px)' : 'blur(4px)',
     }, transition);
-  });
+  }, { defer: true }));
 
   onCleanup(() => {
     addTapAnim?.stop();
@@ -137,7 +118,6 @@ export function Panel(props: PanelProps) {
   };
 
   const handleOpenChange = (open: boolean) => {
-    setIsPanelOpen(open);
     props.onOpenChange?.(open);
   };
 
@@ -287,7 +267,7 @@ export function Panel(props: PanelProps) {
           <span
             ref={copyClipboardIconRef}
             class="dialkit-toolbar-copy-icon"
-            style={{ opacity: 1, transform: 'scale(1)', filter: 'blur(0px)' }}
+            style={{ opacity: 1, transform: 'scale(1)', filter: 'blur(0px)', 'transform-origin': '50% 50%' }}
           >
             <svg viewBox="0 0 24 24" fill="none" width="16" height="16">
               <path d={ICON_CLIPBOARD.board} stroke="currentColor" stroke-width="2" stroke-linejoin="round" />
@@ -298,7 +278,7 @@ export function Panel(props: PanelProps) {
           <span
             ref={copyCheckIconRef}
             class="dialkit-toolbar-copy-icon"
-            style={{ opacity: 0, transform: 'scale(0.5)', filter: 'blur(4px)' }}
+            style={{ opacity: 0, transform: 'scale(0.5)', filter: 'blur(4px)', 'transform-origin': '50% 50%' }}
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="16" height="16">
               <path d={ICON_CHECK} />
@@ -324,9 +304,9 @@ export function Panel(props: PanelProps) {
 
   return (
     <div class="dialkit-panel-wrapper">
-      <Folder title={props.panel.name} defaultOpen={props.defaultOpen ?? true} isRoot={true} inline={props.inline ?? false} onOpenChange={handleOpenChange} toolbar={toolbar}>
+      <RootPanel title={props.panel.name} defaultOpen={props.defaultOpen ?? true} inline={props.inline ?? false} onOpenChange={handleOpenChange} toolbar={toolbar}>
         {renderControls()}
-      </Folder>
+      </RootPanel>
     </div>
   );
 }

--- a/src/solid/components/PresetManager.tsx
+++ b/src/solid/components/PresetManager.tsx
@@ -1,10 +1,11 @@
-import { createSignal, createEffect, onMount, onCleanup, Show, For } from 'solid-js';
+import { createSignal, createEffect, on, onMount, onCleanup, Show, For } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { animate } from 'motion';
 import { ICON_CHEVRON, ICON_TRASH } from '../../icons';
 import { getDialKitPortalRoot, getDropdownPosition } from '../../dropdown-position';
 import { DialStore } from '../../store/DialStore';
 import type { Preset } from '../../store/DialStore';
+import { createDropdownDismiss, createDropdownPresence, type AnimationHandle } from '../primitives';
 
 interface PresetManagerProps {
   panelId: string;
@@ -14,44 +15,38 @@ interface PresetManagerProps {
 }
 
 export function PresetManager(props: PresetManagerProps) {
-  const [isOpen, setIsOpen] = createSignal(false);
-  const [mounted, setMounted] = createSignal(false);
   const [pos, setPos] = createSignal({ top: 0, left: 0, width: 0 });
   const [portalTarget, setPortalTarget] = createSignal<HTMLElement | null>(null);
   let triggerRef!: HTMLButtonElement;
-  let dropdownRef: HTMLDivElement | undefined;
   let chevronRef!: SVGSVGElement;
-  let closeAnim: any = null;
-  let chevronAnim: any = null;
+  let chevronAnim: AnimationHandle | null = null;
 
   const hasPresets = () => props.presets.length > 0;
   const activePreset = () => props.presets.find((p) => p.id === props.activePresetId);
 
+  const dropdown = createDropdownPresence((el, done) =>
+    animate(
+      el,
+      { opacity: 0, y: 4, scale: 0.97 },
+      { type: 'spring', visualDuration: 0.15, bounce: 0, onComplete: done }
+    )
+  );
+
   onMount(() => {
     setPortalTarget(getDialKitPortalRoot(triggerRef) ?? document.body);
-
-    if (chevronRef) {
-      chevronRef.style.transform = `rotate(${isOpen() ? 180 : 0}deg)`;
-      chevronRef.style.opacity = String(hasPresets() ? 0.6 : 0.25);
-    }
-
-    onCleanup(() => {
-      closeAnim?.stop();
-      chevronAnim?.stop();
-    });
+    onCleanup(() => chevronAnim?.stop());
   });
 
-  createEffect(() => {
+  // Renders at its resting state via inline style; animate on changes only.
+  createEffect(on([dropdown.isOpen, hasPresets] as const, ([open, has]) => {
     if (!chevronRef) return;
-    const open = isOpen();
-    const has = hasPresets();
     chevronAnim?.stop();
     chevronAnim = animate(
       chevronRef,
       { rotate: open ? 180 : 0, opacity: has ? 0.6 : 0.25 },
       { type: 'spring', visualDuration: 0.2, bounce: 0.15 }
     );
-  });
+  }, { defer: true }));
 
   const updatePos = () => {
     const root = portalTarget();
@@ -62,49 +57,25 @@ export function PresetManager(props: PresetManagerProps) {
   const openDropdown = () => {
     if (!hasPresets()) return;
     updatePos();
-    closeAnim?.stop();
-    closeAnim = null;
-    setMounted(true);
-    setIsOpen(true);
+    dropdown.open();
   };
 
-  const closeDropdown = () => {
-    setIsOpen(false);
-    if (!dropdownRef) { setMounted(false); return; }
-    closeAnim?.stop();
-    closeAnim = animate(
-      dropdownRef,
-      { opacity: 0, y: 4, scale: 0.97 },
-      { type: 'spring', visualDuration: 0.15, bounce: 0, onComplete: () => { setMounted(false); closeAnim = null; } }
-    );
+  const toggle = () => {
+    if (dropdown.isOpen()) dropdown.close();
+    else openDropdown();
   };
 
-  const toggle = () => { if (isOpen()) closeDropdown(); else openDropdown(); };
-
-  // Close on click outside
-  createEffect(() => {
-    if (!isOpen()) return;
-    const handleViewportChange = () => updatePos();
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (triggerRef?.contains(target) || dropdownRef?.contains(target)) return;
-      closeDropdown();
-    };
-    updatePos();
-    document.addEventListener('mousedown', handler);
-    window.addEventListener('resize', handleViewportChange);
-    window.addEventListener('scroll', handleViewportChange, true);
-    onCleanup(() => {
-      document.removeEventListener('mousedown', handler);
-      window.removeEventListener('resize', handleViewportChange);
-      window.removeEventListener('scroll', handleViewportChange, true);
-    });
+  createDropdownDismiss({
+    isOpen: dropdown.isOpen,
+    contains: (target) => triggerRef?.contains(target) || dropdown.contains(target),
+    onDismiss: dropdown.close,
+    onViewportChange: updatePos,
   });
 
   const handleSelect = (presetId: string | null) => {
     if (presetId) DialStore.loadPreset(props.panelId, presetId);
     else DialStore.clearActivePreset(props.panelId);
-    closeDropdown();
+    dropdown.close();
   };
 
   const handleDelete = (e: MouseEvent, presetId: string) => {
@@ -118,7 +89,7 @@ export function PresetManager(props: PresetManagerProps) {
         ref={triggerRef}
         class="dialkit-preset-trigger"
         onClick={toggle}
-        data-open={String(isOpen())}
+        data-open={String(dropdown.isOpen())}
         data-has-preset={String(!!activePreset())}
         data-disabled={String(!hasPresets())}
       >
@@ -134,6 +105,7 @@ export function PresetManager(props: PresetManagerProps) {
           stroke-width="2.5"
           stroke-linecap="round"
           stroke-linejoin="round"
+          style={{ opacity: hasPresets() ? 0.6 : 0.25 }}
         >
           <path d={ICON_CHEVRON} />
         </svg>
@@ -141,10 +113,10 @@ export function PresetManager(props: PresetManagerProps) {
 
       <Show when={!!portalTarget()}>
         <Portal mount={portalTarget()!}>
-          <Show when={mounted()}>
+          <Show when={dropdown.mounted()}>
             <div
               ref={(el) => {
-                dropdownRef = el;
+                dropdown.setRef(el);
                 animate(
                   el,
                   { opacity: [0, 1], y: [4, 0], scale: [0.97, 1] },

--- a/src/solid/components/RootPanel.tsx
+++ b/src/solid/components/RootPanel.tsx
@@ -1,0 +1,193 @@
+import { createSignal, createEffect, on, onCleanup, untrack, Show, JSX } from 'solid-js';
+import { isServer } from 'solid-js/web';
+import { animate } from 'motion';
+import { ICON_PANEL } from '../../icons';
+import type { AnimationHandle } from '../primitives';
+
+export interface RootPanelProps {
+  title: string;
+  children: JSX.Element;
+  defaultOpen?: boolean;
+  inline?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
+  toolbar?: JSX.Element;
+  panelHeightOffset?: number;
+}
+
+const morphTransition = { type: 'spring' as const, visualDuration: 0.15, bounce: 0.3 };
+
+/**
+ * The top-level panel shell: header with panel icon and toolbar, and (in
+ * popover mode) the bubble-to-panel morph animation with drag-friendly
+ * collapsed state. Section folding lives in Folder.
+ */
+export function RootPanel(props: RootPanelProps) {
+  // Inline vs popover picks a different component tree; treat it as static
+  // configuration (DialRoot never changes mode at runtime).
+  const inline = props.inline ?? false;
+
+  const [isOpen, setIsOpen] = createSignal(props.defaultOpen ?? true);
+  const [contentHeight, setContentHeight] = createSignal<number | undefined>(undefined);
+  const [windowHeight, setWindowHeight] = createSignal(isServer ? 800 : window.innerHeight);
+  let folderRef: HTMLDivElement | undefined;
+
+  const handleToggle = () => {
+    if (inline) return;
+    const next = !isOpen();
+    setIsOpen(next);
+    props.onOpenChange?.(next);
+  };
+
+  const folderContent = () => (
+    <div ref={folderRef} class="dialkit-folder dialkit-folder-root" data-open={String(isOpen())}>
+      <div class="dialkit-folder-header dialkit-panel-header" onClick={handleToggle}>
+        <div class="dialkit-folder-header-top">
+          <Show when={isOpen()}>
+            <div class="dialkit-folder-title-row">
+              <span class="dialkit-folder-title dialkit-folder-title-root">
+                {props.title}
+              </span>
+            </div>
+          </Show>
+
+          <Show when={!inline}>
+            <svg class="dialkit-panel-icon" viewBox="0 0 16 16" fill="none">
+              <path
+                opacity="0.5"
+                d={ICON_PANEL.path}
+                fill="currentColor"
+              />
+              <circle cx={ICON_PANEL.circles[0].cx} cy={ICON_PANEL.circles[0].cy} r={ICON_PANEL.circles[0].r} fill="currentColor" stroke="currentColor" stroke-width="1.25" />
+              <circle cx={ICON_PANEL.circles[1].cx} cy={ICON_PANEL.circles[1].cy} r={ICON_PANEL.circles[1].r} fill="currentColor" stroke="currentColor" stroke-width="1.25" />
+              <circle cx={ICON_PANEL.circles[2].cx} cy={ICON_PANEL.circles[2].cy} r={ICON_PANEL.circles[2].r} fill="currentColor" stroke="currentColor" stroke-width="1.25" />
+            </svg>
+          </Show>
+        </div>
+
+        <Show when={props.toolbar && isOpen()}>
+          <div class="dialkit-panel-toolbar" onClick={(e) => e.stopPropagation()}>
+            {props.toolbar}
+          </div>
+        </Show>
+      </div>
+
+      <Show when={isOpen()}>
+        <div class="dialkit-folder-content">
+          <div class="dialkit-folder-inner">{props.children}</div>
+        </div>
+      </Show>
+    </div>
+  );
+
+  if (inline) {
+    return (
+      <div class="dialkit-panel-inner dialkit-panel-inline">
+        {folderContent()}
+      </div>
+    );
+  }
+
+  let panelRef!: HTMLDivElement;
+  let morphAnim: AnimationHandle | null = null;
+  let tapAnim: AnimationHandle | null = null;
+
+  const onWindowResize = () => setWindowHeight(window.innerHeight);
+  window.addEventListener('resize', onWindowResize);
+  onCleanup(() => {
+    window.removeEventListener('resize', onWindowResize);
+    morphAnim?.stop();
+    tapAnim?.stop();
+  });
+
+  // Measure the whole folder (header + content) to size the open panel.
+  createEffect(() => {
+    if (!isOpen()) return;
+    const el = folderRef;
+    if (!el) return;
+    const ro = new ResizeObserver(() => {
+      const h = el.offsetHeight;
+      setContentHeight((prev) => (prev === h ? prev : h));
+    });
+    ro.observe(el);
+    onCleanup(() => ro.disconnect());
+  });
+
+  const measuredOpenHeight = () => (
+    contentHeight() !== undefined
+      ? Math.min(contentHeight()! + (props.panelHeightOffset ?? 10), windowHeight() - 32)
+      : panelRef.getBoundingClientRect().height
+  );
+
+  // Bubble <-> panel morph: first run just applies resting styles; later
+  // open-state changes animate. on() keeps height reads untracked so only
+  // transitions trigger the morph.
+  createEffect(on(isOpen, (open, prevOpen) => {
+    const target = {
+      width: open ? 280 : 42,
+      height: open ? measuredOpenHeight() : 42,
+      borderRadius: open ? 14 : 21,
+      boxShadow: open ? 'var(--dial-shadow)' : 'var(--dial-shadow-collapsed)',
+    };
+
+    panelRef.style.cursor = open ? '' : 'pointer';
+    panelRef.style.overflow = open ? 'hidden auto' : 'hidden';
+
+    if (prevOpen === undefined) {
+      panelRef.style.width = `${target.width}px`;
+      panelRef.style.height = `${target.height}px`;
+      panelRef.style.borderRadius = `${target.borderRadius}px`;
+      panelRef.style.boxShadow = target.boxShadow;
+      return;
+    }
+
+    morphAnim?.stop();
+    morphAnim = animate(panelRef, target, {
+      ...morphTransition,
+      onComplete: () => {
+        morphAnim = null;
+      },
+    });
+  }));
+
+  // Track content growth/shrink while open without re-triggering the morph.
+  createEffect(on([contentHeight, windowHeight] as const, ([height, winHeight]) => {
+    if (height === undefined || !untrack(isOpen)) return;
+    panelRef.style.height = `${Math.min(height + (props.panelHeightOffset ?? 10), winHeight - 32)}px`;
+  }, { defer: true }));
+
+  // Expand-on-tap while collapsed uses a native listener: stopPropagation here
+  // prevents the (delegated) header onClick from firing a second toggle.
+  createEffect(() => {
+    if (isOpen()) return;
+    const handler = (e: Event) => {
+      e.stopPropagation();
+      handleToggle();
+    };
+    panelRef.addEventListener('click', handler);
+    onCleanup(() => panelRef.removeEventListener('click', handler));
+  });
+
+  const pressTo = (scale: number) => {
+    if (isOpen()) return;
+    tapAnim?.stop();
+    tapAnim = animate(panelRef, { scale }, morphTransition);
+  };
+
+  return (
+    <div
+      ref={panelRef}
+      class="dialkit-panel-inner"
+      data-collapsed={String(!isOpen())}
+      onPointerDown={() => {
+        if (isOpen()) return;
+        (document.activeElement as HTMLElement)?.blur?.();
+        pressTo(0.9);
+      }}
+      onPointerUp={() => pressTo(1)}
+      onPointerCancel={() => pressTo(1)}
+      onPointerLeave={() => pressTo(1)}
+    >
+      {folderContent()}
+    </div>
+  );
+}

--- a/src/solid/components/SelectControl.tsx
+++ b/src/solid/components/SelectControl.tsx
@@ -1,8 +1,9 @@
-import { createSignal, createEffect, onMount, onCleanup, Show, For } from 'solid-js';
+import { createSignal, createEffect, on, onMount, onCleanup, Show, For } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { animate } from 'motion';
 import { getDialKitPortalRoot, getDropdownPosition } from '../../dropdown-position';
 import { ICON_CHEVRON } from '../../icons';
+import { createDropdownDismiss, createDropdownPresence, type AnimationHandle } from '../primitives';
 
 type SelectOption = string | { value: string; label: string };
 
@@ -24,42 +25,38 @@ function normalizeOptions(options: SelectOption[]): { value: string; label: stri
 }
 
 export function SelectControl(props: SelectControlProps) {
-  const [isOpen, setIsOpen] = createSignal(false);
-  const [mounted, setMounted] = createSignal(false);
   const [pos, setPos] = createSignal<{ top: number; left: number; width: number; above: boolean } | null>(null);
   const [portalTarget, setPortalTarget] = createSignal<HTMLElement | null>(null);
   let triggerRef!: HTMLButtonElement;
-  let dropdownRef: HTMLDivElement | undefined;
   let chevronRef!: SVGSVGElement;
-  let closeAnim: any = null;
-  let chevronAnim: any = null;
+  let chevronAnim: AnimationHandle | null = null;
 
   const normalized = () => normalizeOptions(props.options);
   const selectedOption = () => normalized().find((o) => o.value === props.value);
 
+  const dropdown = createDropdownPresence((el, done) =>
+    animate(
+      el,
+      { opacity: 0, y: (pos()?.above ?? false) ? 8 : -8, scale: 0.95 },
+      { type: 'spring', visualDuration: 0.15, bounce: 0, onComplete: done }
+    )
+  );
+
   onMount(() => {
     setPortalTarget(getDialKitPortalRoot(triggerRef) ?? document.body);
-
-    if (chevronRef) {
-      chevronRef.style.transform = `rotate(${isOpen() ? 180 : 0}deg)`;
-    }
-
-    onCleanup(() => {
-      closeAnim?.stop();
-      chevronAnim?.stop();
-    });
+    onCleanup(() => chevronAnim?.stop());
   });
 
-  createEffect(() => {
+  // Chevron renders at its resting angle; only animate on changes.
+  createEffect(on(dropdown.isOpen, (open) => {
     if (!chevronRef) return;
-    const open = isOpen();
     chevronAnim?.stop();
     chevronAnim = animate(
       chevronRef,
       { rotate: open ? 180 : 0 },
       { type: 'spring', visualDuration: 0.2, bounce: 0.15 }
     );
-  });
+  }, { defer: true }));
 
   const updatePos = () => {
     const root = portalTarget();
@@ -69,49 +66,15 @@ export function SelectControl(props: SelectControlProps) {
   };
 
   const openDropdown = () => {
-    closeAnim?.stop();
-    closeAnim = null;
     updatePos();
-    setMounted(true);
-    setIsOpen(true);
+    dropdown.open();
   };
 
-  const closeDropdown = () => {
-    setIsOpen(false);
-    if (!dropdownRef) { setMounted(false); return; }
-    const above = pos()?.above ?? false;
-    closeAnim?.stop();
-    closeAnim = animate(
-      dropdownRef,
-      { opacity: 0, y: above ? 8 : -8, scale: 0.95 },
-      { type: 'spring', visualDuration: 0.15, bounce: 0, onComplete: () => { setMounted(false); closeAnim = null; } }
-    );
-  };
-
-  // Close on click outside
-  createEffect(() => {
-    if (!isOpen()) return;
-    const handleViewportChange = () => updatePos();
-
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (
-        triggerRef && !triggerRef.contains(target) &&
-        dropdownRef && !dropdownRef.contains(target)
-      ) {
-        closeDropdown();
-      }
-    };
-
-    updatePos();
-    document.addEventListener('mousedown', handleClick);
-    window.addEventListener('resize', handleViewportChange);
-    window.addEventListener('scroll', handleViewportChange, true);
-    onCleanup(() => {
-      document.removeEventListener('mousedown', handleClick);
-      window.removeEventListener('resize', handleViewportChange);
-      window.removeEventListener('scroll', handleViewportChange, true);
-    });
+  createDropdownDismiss({
+    isOpen: dropdown.isOpen,
+    contains: (target) => triggerRef?.contains(target) || dropdown.contains(target),
+    onDismiss: dropdown.close,
+    onViewportChange: updatePos,
   });
 
   const dropdownStyle = () => {
@@ -131,8 +94,8 @@ export function SelectControl(props: SelectControlProps) {
       <button
         ref={triggerRef}
         class="dialkit-select-trigger"
-        onClick={() => isOpen() ? closeDropdown() : openDropdown()}
-        data-open={String(isOpen())}
+        onClick={() => dropdown.isOpen() ? dropdown.close() : openDropdown()}
+        data-open={String(dropdown.isOpen())}
       >
         <span class="dialkit-select-label">{props.label}</span>
         <div class="dialkit-select-right">
@@ -154,10 +117,10 @@ export function SelectControl(props: SelectControlProps) {
 
       <Show when={!!portalTarget()}>
         <Portal mount={portalTarget()!}>
-          <Show when={mounted() && pos()}>
+          <Show when={dropdown.mounted() && pos()}>
             <div
               ref={(el) => {
-                dropdownRef = el;
+                dropdown.setRef(el);
                 const above = pos()?.above ?? false;
                 animate(
                   el,
@@ -175,7 +138,7 @@ export function SelectControl(props: SelectControlProps) {
                     data-selected={String(option.value === props.value)}
                     onClick={() => {
                       props.onChange(option.value);
-                      closeDropdown();
+                      dropdown.close();
                     }}
                   >
                     {option.label}

--- a/src/solid/components/ShortcutsMenu.tsx
+++ b/src/solid/components/ShortcutsMenu.tsx
@@ -1,7 +1,8 @@
-import { createSignal, createEffect, onCleanup, Show, For } from 'solid-js';
+import { createSignal, onCleanup, Show, For } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import { animate } from 'motion';
 import { DialStore, ShortcutConfig } from '../../store/DialStore';
+import { createDropdownDismiss, createDropdownPresence, type AnimationHandle } from '../primitives';
 
 interface ShortcutsMenuProps {
   panelId: string;
@@ -27,79 +28,41 @@ function formatInteraction(sc: ShortcutConfig): string {
 }
 
 export function ShortcutsMenu(props: ShortcutsMenuProps) {
-  const [isOpen, setIsOpen] = createSignal(false);
   const [pos, setPos] = createSignal({ top: 0, right: 0 });
 
   let triggerRef!: HTMLButtonElement;
-  let dropdownRef: HTMLDivElement | undefined;
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let triggerTapAnim: any = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let dropdownEnterAnim: any = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let dropdownExitAnim: any = null;
+  let triggerTapAnim: AnimationHandle | null = null;
 
   const tapTransition = { type: 'spring' as const, visualDuration: 0.15, bounce: 0.3 };
+
+  const dropdown = createDropdownPresence((el, done) =>
+    animate(
+      el,
+      { opacity: 0, y: 4, scale: 0.97 },
+      { type: 'spring', visualDuration: 0.15, bounce: 0, onComplete: done }
+    )
+  );
 
   const open = () => {
     const rect = triggerRef?.getBoundingClientRect();
     if (rect) {
       setPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right });
     }
-    setIsOpen(true);
+    dropdown.open();
   };
 
-  const close = () => setIsOpen(false);
-
   const toggle = () => {
-    if (isOpen()) close();
+    if (dropdown.isOpen()) dropdown.close();
     else open();
   };
 
-  // Close on mousedown outside
-  createEffect(() => {
-    if (!isOpen()) return;
-
-    const handler = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (triggerRef?.contains(target) || dropdownRef?.contains(target)) return;
-      close();
-    };
-
-    document.addEventListener('mousedown', handler);
-    onCleanup(() => document.removeEventListener('mousedown', handler));
+  createDropdownDismiss({
+    isOpen: dropdown.isOpen,
+    contains: (target) => triggerRef?.contains(target) || dropdown.contains(target),
+    onDismiss: dropdown.close,
   });
 
-  // Animate dropdown enter/exit
-  createEffect(() => {
-    const opened = isOpen();
-    if (!dropdownRef) return;
-
-    if (opened) {
-      dropdownExitAnim?.stop();
-      dropdownRef.style.pointerEvents = 'auto';
-      dropdownEnterAnim = animate(
-        dropdownRef,
-        { opacity: 1, y: 0, scale: 1 },
-        { type: 'spring', visualDuration: 0.15, bounce: 0 }
-      );
-    } else {
-      dropdownEnterAnim?.stop();
-      dropdownRef.style.pointerEvents = 'none';
-      dropdownExitAnim = animate(
-        dropdownRef,
-        { opacity: 0, y: 4, scale: 0.97 },
-        { type: 'spring', visualDuration: 0.15, bounce: 0 }
-      );
-    }
-  });
-
-  onCleanup(() => {
-    triggerTapAnim?.stop();
-    dropdownEnterAnim?.stop();
-    dropdownExitAnim?.stop();
-  });
+  onCleanup(() => triggerTapAnim?.stop());
 
   const panel = () => DialStore.getPanel(props.panelId);
 
@@ -128,28 +91,21 @@ export function ShortcutsMenu(props: ShortcutsMenuProps) {
     });
   };
 
+  const tapTo = (scale: number) => {
+    triggerTapAnim?.stop();
+    triggerTapAnim = animate(triggerRef, { scale }, tapTransition);
+  };
+
   return (
     <>
       <button
         ref={triggerRef}
         class="dialkit-shortcuts-trigger"
         onClick={toggle}
-        onPointerDown={() => {
-          triggerTapAnim?.stop();
-          triggerTapAnim = animate(triggerRef, { scale: 0.9 }, tapTransition);
-        }}
-        onPointerUp={() => {
-          triggerTapAnim?.stop();
-          triggerTapAnim = animate(triggerRef, { scale: 1 }, tapTransition);
-        }}
-        onPointerCancel={() => {
-          triggerTapAnim?.stop();
-          triggerTapAnim = animate(triggerRef, { scale: 1 }, tapTransition);
-        }}
-        onPointerLeave={() => {
-          triggerTapAnim?.stop();
-          triggerTapAnim = animate(triggerRef, { scale: 1 }, tapTransition);
-        }}
+        onPointerDown={() => tapTo(0.9)}
+        onPointerUp={() => tapTo(1)}
+        onPointerCancel={() => tapTo(1)}
+        onPointerLeave={() => tapTo(1)}
         title="Keyboard shortcuts"
       >
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -162,39 +118,42 @@ export function ShortcutsMenu(props: ShortcutsMenuProps) {
         </svg>
       </button>
 
-      <Portal mount={document.body}>
-        <div
-          ref={(el) => {
-            dropdownRef = el;
-            // Initialize hidden
-            el.style.opacity = '0';
-            el.style.transform = 'translateY(4px) scale(0.97)';
-            el.style.pointerEvents = 'none';
-          }}
-          class="dialkit-root dialkit-shortcuts-dropdown"
-          style={{
-            position: 'fixed',
-            top: `${pos().top}px`,
-            right: `${pos().right}px`,
-          }}
-        >
-          <div class="dialkit-shortcuts-title">Keyboard Shortcuts</div>
-          <div class="dialkit-shortcuts-list">
-            <For each={rows()}>
-              {(row) => (
-                <div class="dialkit-shortcuts-row">
-                  <span class="dialkit-shortcuts-row-key">
-                    {formatShortcutKey(row.shortcut)}
-                  </span>
-                  <span class="dialkit-shortcuts-row-label">{row.label}</span>
-                  <span class="dialkit-shortcuts-row-mode">{formatInteraction(row.shortcut)}</span>
-                </div>
-              )}
-            </For>
+      <Show when={dropdown.mounted()}>
+        <Portal mount={document.body}>
+          <div
+            ref={(el) => {
+              dropdown.setRef(el);
+              animate(
+                el,
+                { opacity: [0, 1], y: [4, 0], scale: [0.97, 1] },
+                { type: 'spring', visualDuration: 0.15, bounce: 0 }
+              );
+            }}
+            class="dialkit-root dialkit-shortcuts-dropdown"
+            style={{
+              position: 'fixed',
+              top: `${pos().top}px`,
+              right: `${pos().right}px`,
+            }}
+          >
+            <div class="dialkit-shortcuts-title">Keyboard Shortcuts</div>
+            <div class="dialkit-shortcuts-list">
+              <For each={rows()}>
+                {(row) => (
+                  <div class="dialkit-shortcuts-row">
+                    <span class="dialkit-shortcuts-row-key">
+                      {formatShortcutKey(row.shortcut)}
+                    </span>
+                    <span class="dialkit-shortcuts-row-label">{row.label}</span>
+                    <span class="dialkit-shortcuts-row-mode">{formatInteraction(row.shortcut)}</span>
+                  </div>
+                )}
+              </For>
+            </div>
+            <div class="dialkit-shortcuts-hint">See pill badges on controls for keys</div>
           </div>
-          <div class="dialkit-shortcuts-hint">See pill badges on controls for keys</div>
-        </div>
-      </Portal>
+        </Portal>
+      </Show>
     </>
   );
 }

--- a/src/solid/components/Slider.tsx
+++ b/src/solid/components/Slider.tsx
@@ -1,6 +1,7 @@
 import { createSignal, createEffect, onMount, onCleanup, Show } from 'solid-js';
 import { animate, motionValue } from 'motion';
 import type { ShortcutConfig } from '../../store/DialStore';
+import type { AnimationHandle } from '../primitives';
 import {
   decimalsForStep,
   roundValue,
@@ -84,16 +85,11 @@ export function Slider(props: SliderProps) {
   let wrapperRect: DOMRect | null = null;
   let scaleVal = 1;
   let hoverTimeout: ReturnType<typeof setTimeout> | null = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let snapAnim: any = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let rubberAnim: any = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let handleOpacityAnim: any = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let handleScaleXAnim: any = null;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  let handleScaleYAnim: any = null;
+  let snapAnim: AnimationHandle | null = null;
+  let rubberAnim: AnimationHandle | null = null;
+  let handleOpacityAnim: AnimationHandle | null = null;
+  let handleScaleXAnim: AnimationHandle | null = null;
+  let handleScaleYAnim: AnimationHandle | null = null;
 
   const positionToValue = (clientX: number) => {
     if (!wrapperRect) return props.value;

--- a/src/solid/components/SpringControl.tsx
+++ b/src/solid/components/SpringControl.tsx
@@ -1,6 +1,6 @@
-import { createSignal, onMount, onCleanup } from 'solid-js';
 import { DialStore } from '../../store/DialStore';
 import type { SpringConfig } from '../../store/DialStore';
+import { fromStore } from '../primitives';
 import { Folder } from './Folder';
 import { Slider } from './Slider';
 import { SegmentedControl } from './SegmentedControl';
@@ -15,17 +15,10 @@ interface SpringControlProps {
 }
 
 export function SpringControl(props: SpringControlProps) {
-  const [mode, setMode] = createSignal<'simple' | 'advanced'>(
-    DialStore.getSpringMode(props.panelId, props.path)
+  const mode = fromStore(
+    () => DialStore.getSpringMode(props.panelId, props.path),
+    (notify) => DialStore.subscribe(props.panelId, notify)
   );
-
-  // Subscribe to store changes for mode
-  onMount(() => {
-    const unsub = DialStore.subscribe(props.panelId, () => {
-      setMode(DialStore.getSpringMode(props.panelId, props.path));
-    });
-    onCleanup(unsub);
-  });
 
   const isSimpleMode = () => mode() === 'simple';
 

--- a/src/solid/components/SpringVisualization.tsx
+++ b/src/solid/components/SpringVisualization.tsx
@@ -76,17 +76,23 @@ export function SpringVisualization(props: SpringVisualizationProps) {
   };
 
   const gridLines = () => {
-    const lines = [];
+    const lines: ReturnType<typeof createLine>[] = [];
     for (let i = 1; i < 4; i++) {
       const x = (width / 4) * i;
       const y = (height / 4) * i;
       lines.push(
-        <line x1={x} y1={0} x2={x} y2={height} stroke="rgba(255, 255, 255, 0.08)" stroke-width="1" />,
-        <line x1={0} y1={y} x2={width} y2={y} stroke="rgba(255, 255, 255, 0.08)" stroke-width="1" />
+        createLine(x, 0, x, height),
+        createLine(0, y, width, y),
       );
     }
     return lines;
   };
+
+  function createLine(x1: number, y1: number, x2: number, y2: number) {
+    return (
+      <line x1={x1} y1={y1} x2={x2} y2={y2} stroke="rgba(255, 255, 255, 0.08)" stroke-width="1" />
+    );
+  }
 
   return (
     <svg viewBox={`0 0 ${width} ${height}`} class="dialkit-spring-viz">

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -10,6 +10,7 @@ export type { DialPosition, DialMode, DialTheme } from './components/DialRoot';
 export { Slider } from './components/Slider';
 export { Toggle } from './components/Toggle';
 export { Folder } from './components/Folder';
+export { RootPanel } from './components/RootPanel';
 export { ButtonGroup } from './components/ButtonGroup';
 export { SpringControl } from './components/SpringControl';
 export { SpringVisualization } from './components/SpringVisualization';

--- a/src/solid/primitives.ts
+++ b/src/solid/primitives.ts
@@ -1,0 +1,119 @@
+import { createEffect, createSignal, from, onCleanup, type Accessor } from 'solid-js';
+import { isServer } from 'solid-js/web';
+import type { animate } from 'motion';
+
+/** Handle returned by motion's `animate()`; used instead of `any` for stored animations. */
+export type AnimationHandle = ReturnType<typeof animate>;
+
+/**
+ * Bridge an external subscribe/read store (DialStore et al.) into a Solid accessor.
+ * Subscribes at setup on the client so updates between setup and mount are not
+ * missed; on the server it reads directly without subscribing, so per-request
+ * renders never leak listeners on the module-level store singleton.
+ */
+export function fromStore<T>(
+  read: () => T,
+  subscribe: (notify: () => void) => () => void
+): Accessor<T> {
+  if (isServer) return read;
+  const value = from<T>((set) => {
+    // Wrap in an updater so values are never mistaken for setter callbacks.
+    set(() => read());
+    return subscribe(() => set(() => read()));
+  });
+  return value as Accessor<T>;
+}
+
+export interface DropdownPresence {
+  /** Logical open state (drives trigger styling, outside-click handling). */
+  isOpen: Accessor<boolean>;
+  /** DOM presence: stays true during the exit animation so it can play out. */
+  mounted: Accessor<boolean>;
+  open: () => void;
+  close: () => void;
+  /** Attach to the dropdown element via `ref`. */
+  setRef: (el: HTMLElement) => void;
+  contains: (target: Node) => boolean;
+}
+
+/**
+ * Mount/unmount bookkeeping for an animated dropdown: `open()` mounts
+ * immediately (the call site's ref callback runs the enter animation),
+ * `close()` plays the provided exit animation and unmounts on completion.
+ * Interrupted exits are stopped and re-opened cleanly.
+ */
+export function createDropdownPresence(
+  animateExit: (el: HTMLElement, done: () => void) => AnimationHandle
+): DropdownPresence {
+  const [isOpen, setIsOpen] = createSignal(false);
+  const [mounted, setMounted] = createSignal(false);
+  let el: HTMLElement | undefined;
+  let exitAnim: AnimationHandle | null = null;
+
+  onCleanup(() => exitAnim?.stop());
+
+  const open = () => {
+    exitAnim?.stop();
+    exitAnim = null;
+    setMounted(true);
+    setIsOpen(true);
+  };
+
+  const close = () => {
+    setIsOpen(false);
+    if (!el || !mounted()) {
+      setMounted(false);
+      return;
+    }
+    exitAnim?.stop();
+    exitAnim = animateExit(el, () => {
+      setMounted(false);
+      exitAnim = null;
+    });
+  };
+
+  return {
+    isOpen,
+    mounted,
+    open,
+    close,
+    setRef: (node: HTMLElement) => {
+      el = node;
+    },
+    contains: (target: Node) => Boolean(el?.contains(target)),
+  };
+}
+
+/**
+ * While `isOpen`, dismiss on mousedown outside of `contains` and invoke
+ * `onViewportChange` on window resize/scroll (for repositioning portaled
+ * dropdowns). Listeners detach automatically when closed or unmounted.
+ */
+export function createDropdownDismiss(opts: {
+  isOpen: Accessor<boolean>;
+  contains: (target: Node) => boolean;
+  onDismiss: () => void;
+  onViewportChange?: () => void;
+}): void {
+  createEffect(() => {
+    if (!opts.isOpen()) return;
+
+    const onMouseDown = (e: MouseEvent) => {
+      if (e.target instanceof Node && opts.contains(e.target)) return;
+      opts.onDismiss();
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    onCleanup(() => document.removeEventListener('mousedown', onMouseDown));
+
+    const onViewportChange = opts.onViewportChange;
+    if (onViewportChange) {
+      const handler = () => onViewportChange();
+      window.addEventListener('resize', handler);
+      window.addEventListener('scroll', handler, true);
+      onCleanup(() => {
+        window.removeEventListener('resize', handler);
+        window.removeEventListener('scroll', handler, true);
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary

A pass over the Solid components to lean on Solid's primitives instead of manual DOM bookkeeping. No visual or API changes intended; the only public addition is the `RootPanel` export.

- **DialRoot**: the panel list now comes from a `from`-based subscription to `DialStore`, and the open/collapsed state that previously drove a `data-collapsed` `MutationObserver` is lifted into `onOpenChange` callbacks — components report state changes instead of the root scraping them back out of the DOM.
- **Folder split**: `Folder` was two components in one file — the root panel (bubble morph animation, collapsed tap target, drag handle) and plain collapsible sections. Root concerns move to a new `RootPanel`; `Folder` keeps only section behavior. `Folder` with `isRoot` still renders `RootPanel`, so existing call sites are unaffected.
- **Shared dropdown primitives**: `SelectControl`, `PresetManager`, and `ShortcutsMenu` each hand-rolled the same mount/exit-animation/outside-dismiss logic with subtle differences (`ShortcutsMenu` kept its menu permanently mounted, toggling `pointer-events`). A shared `createDropdownPresence`/`createDropdownDismiss` pair in `src/solid/primitives.ts` replaces the three copies, so all dropdowns get the same enter/exit and dismiss behavior.
- **Mount-safe animations**: effects that animate on state changes use `on(..., { defer: true })` with initial styles rendered inline, so mount no longer plays transitions or needs did-init flags.
- **Typing**: stored animation handles are `AnimationHandle` (`ReturnType<typeof animate>`) instead of `any`, and `Panel` batches its store-driven signal updates.

This is independent of my other open PRs — it applies cleanly on main with or without them.

## Test plan

- [x] `npm run typecheck` (all four framework configs) passes
- [x] `npm run build` passes
- [x] Headless-browser smoke test against a Vite + Solid app: panel renders, slider drag and toggle update consumers, root panel collapses to bubble via header click and re-expands, dropdowns open/dismiss — no console errors

Made with [Cursor](https://cursor.com)