### PR TITLE
feat: add collapsed settings and controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dialkit v1.4.3
+# dialkit v1.4.4
 
 <img src="https://joshpuckett.me/images/dialkit.png" width="100%" />
 
@@ -20,8 +20,8 @@ npm install dialkit motion
 
 ```tsx
 // layout.tsx
-import { DialRoot } from 'dialkit';
-import 'dialkit/styles.css';
+import { DialRoot } from "dialkit";
+import "dialkit/styles.css";
 
 export default function Layout({ children }) {
   return (
@@ -37,23 +37,25 @@ export default function Layout({ children }) {
 
 ```tsx
 // component.tsx
-import { useDialKit } from 'dialkit';
+import { useDialKit } from "dialkit";
 
 function Card() {
-  const p = useDialKit('Card', {
+  const p = useDialKit("Card", {
     blur: [24, 0, 100],
     scale: 1.2,
-    color: '#ff5500',
+    color: "#ff5500",
     visible: true,
   });
 
   return (
-    <div style={{
-      filter: `blur(${p.blur}px)`,
-      transform: `scale(${p.scale})`,
-      color: p.color,
-      opacity: p.visible ? 1 : 0,
-    }}>
+    <div
+      style={{
+        filter: `blur(${p.blur}px)`,
+        transform: `scale(${p.scale})`,
+        color: p.color,
+        opacity: p.visible ? 1 : 0,
+      }}
+    >
       ...
     </div>
   );
@@ -68,14 +70,14 @@ function Card() {
 const params = useDialKit(name, config, options?)
 ```
 
-| Param | Type | Description |
-|-------|------|-------------|
-| `name` | `string` | Panel title displayed in the UI |
-| `config` | `DialConfig` | Parameter definitions (see Control Types below) |
-| `options.id` | `string` | Stable logical id for sharing values across remounts/pages |
-| `options.persist` | `DialKitPersistOptions` | Persist values to browser storage |
-| `options.collapsed` | `boolean` | Start this panel collapsed (see [Panel open state](#panel-open-state)) |
-| `options.onAction` | `(path: string) => void` | Callback when action buttons are clicked |
+| Param               | Type                             | Description                                                                     |
+| ------------------- | -------------------------------- | ------------------------------------------------------------------------------- |
+| `name`              | `string`                         | Panel title displayed in the UI                                                 |
+| `config`            | `DialConfig`                     | Parameter definitions (see Control Types below)                                 |
+| `options.id`        | `string`                         | Stable logical id for sharing values across remounts/pages                      |
+| `options.persist`   | `DialKitPersistOptions`          | Persist values to browser storage                                               |
+| `options.collapsed` | `boolean`                        | Start this panel collapsed (see [Panel open state](#panel-open-state))          |
+| `options.onAction`  | `(path: string) => void`         | Callback when action buttons are clicked                                        |
 | `options.shortcuts` | `Record<string, ShortcutConfig>` | Keyboard shortcuts for controls (see [Keyboard Shortcuts](#keyboard-shortcuts)) |
 
 Returns a fully typed object matching your config shape with live values. Updating a control in the UI immediately updates the returned values.
@@ -88,17 +90,21 @@ By default, a DialKit panel is tied to the lifecycle of the component that calls
 
 ```tsx
 // dials/useOnboardingDials.ts
-import { useDialKit } from 'dialkit';
+import { useDialKit } from "dialkit";
 
 export function useOnboardingDials() {
-  return useDialKit('Onboarding', {
-    name: { type: 'text', default: 'Avery', placeholder: 'Name' },
-    avatarScale: [1, 0.6, 1.6, 0.01],
-    accent: { type: 'color', default: '#6C5CE7' },
-  }, {
-    id: 'onboarding',
-    persist: true,
-  });
+  return useDialKit(
+    "Onboarding",
+    {
+      name: { type: "text", default: "Avery", placeholder: "Name" },
+      avatarScale: [1, 0.6, 1.6, 0.01],
+      accent: { type: "color", default: "#6C5CE7" },
+    },
+    {
+      id: "onboarding",
+      persist: true,
+    },
+  );
 }
 ```
 
@@ -108,7 +114,7 @@ Use that helper anywhere the shared values are needed:
 function PageTwo() {
   const onboarding = useOnboardingDials();
 
-  const page = useDialKit('Page Two', {
+  const page = useDialKit("Page Two", {
     cardRadius: [16, 0, 64],
   });
 
@@ -127,11 +133,11 @@ When `PageTwo` is mounted, the single `<DialRoot />` shows both `Onboarding` and
 `persist: true` stores values, presets, and the active preset in `localStorage` using `dialkit:${id}` as the key. Use the object form to customize storage:
 
 ```tsx
-useDialKit('Onboarding', config, {
-  id: 'onboarding',
+useDialKit("Onboarding", config, {
+  id: "onboarding",
   persist: {
-    key: 'my-app:onboarding-dials',
-    storage: 'sessionStorage',
+    key: "my-app:onboarding-dials",
+    storage: "sessionStorage",
     presets: false,
   },
 });
@@ -146,13 +152,13 @@ The `id` string has no special format; it only needs to be reused wherever you w
 Use the controller API when your app code also needs to update DialKit values, such as reset buttons, URL sync, or app-defined preset buttons.
 
 ```tsx
-import { useDialKitController } from 'dialkit';
+import { useDialKitController } from "dialkit";
 
 function Card() {
-  const dial = useDialKitController('Card', {
+  const dial = useDialKitController("Card", {
     blur: [24, 0, 100],
     scale: 1.2,
-    color: '#ff5500',
+    color: "#ff5500",
     visible: true,
     shadow: {
       radius: [16, 0, 64],
@@ -161,22 +167,28 @@ function Card() {
 
   return (
     <>
-      <button onClick={() => dial.setValues({
-        blur: 48,
-        scale: 1,
-        shadow: { radius: 28 },
-      })}>
+      <button
+        onClick={() =>
+          dial.setValues({
+            blur: 48,
+            scale: 1,
+            shadow: { radius: 28 },
+          })
+        }
+      >
         Apply preset
       </button>
       <button onClick={() => dial.resetValues()}>Reset</button>
 
-      <div style={{
-        filter: `blur(${dial.values.blur}px)`,
-        transform: `scale(${dial.values.scale})`,
-        color: dial.values.color,
-        opacity: dial.values.visible ? 1 : 0,
-        borderRadius: dial.values.shadow.radius,
-      }}>
+      <div
+        style={{
+          filter: `blur(${dial.values.blur}px)`,
+          transform: `scale(${dial.values.scale})`,
+          color: dial.values.color,
+          opacity: dial.values.visible ? 1 : 0,
+          borderRadius: dial.values.shadow.radius,
+        }}
+      >
         ...
       </div>
     </>
@@ -186,13 +198,13 @@ function Card() {
 
 Controller methods:
 
-| Method | Description |
-|--------|-------------|
-| `values` | The same live resolved values returned by `useDialKit` |
-| `setValue(path, value)` | Updates one control by dot path, like `'shadow.radius'` |
-| `setValues(values)` | Updates multiple controls with a typed nested partial object |
-| `resetValues()` | Restores the current config defaults and clears the active preset |
-| `getValues()` | Reads the latest resolved values outside render callbacks |
+| Method                  | Description                                                       |
+| ----------------------- | ----------------------------------------------------------------- |
+| `values`                | The same live resolved values returned by `useDialKit`            |
+| `setValue(path, value)` | Updates one control by dot path, like `'shadow.radius'`           |
+| `setValues(values)`     | Updates multiple controls with a typed nested partial object      |
+| `resetValues()`         | Restores the current config defaults and clears the active preset |
+| `getValues()`           | Reads the latest resolved values outside render callbacks         |
 
 Programmatic updates use the same state as panel edits. If a saved preset is active, updates are saved into that preset; otherwise they update the base "Version 1" values. Action controls are triggers, so they are not set by `setValues`.
 
@@ -205,28 +217,33 @@ Programmatic updates use the same state as panel edits. If a saved preset is act
 Numbers create sliders. There are three ways to define them:
 
 **Explicit range** — `[default, min, max]`:
+
 ```tsx
-blur: [24, 0, 100]
+blur: [24, 0, 100];
 ```
 
 **Explicit range + step** — `[default, min, max, step]`:
+
 ```tsx
-blur: [24, 0, 100, 5]    // snaps in increments of 5
+blur: [24, 0, 100, 5]; // snaps in increments of 5
 ```
+
 When `step` is omitted, it's inferred from the range (see table below).
 
 **Auto-inferred** — bare number:
+
 ```tsx
-scale: 1.2
+scale: 1.2;
 ```
+
 A single number auto-infers a reasonable min, max, and step:
 
-| Value range | Inferred min/max | Step |
-|-------------|-----------------|------|
-| 0–1 | 0 to 1 | 0.01 |
-| 0–10 | 0 to value &times; 3 | 0.1 |
-| 0–100 | 0 to value &times; 3 | 1 |
-| 100+ | 0 to value &times; 3 | 10 |
+| Value range | Inferred min/max     | Step |
+| ----------- | -------------------- | ---- |
+| 0–1         | 0 to 1               | 0.01 |
+| 0–10        | 0 to value &times; 3 | 0.1  |
+| 0–100       | 0 to value &times; 3 | 1    |
+| 100+        | 0 to value &times; 3 | 10   |
 
 **Returns:** `number`
 
@@ -235,8 +252,8 @@ Sliders support click-to-snap (with spring animation), drag with rubber-band ove
 ### Toggle
 
 ```tsx
-enabled: true
-darkMode: false
+enabled: true;
+darkMode: false;
 ```
 
 Booleans create an Off/On segmented control.
@@ -311,12 +328,12 @@ Creates a visual spring editor with a live animation curve preview. The editor s
 The returned config object is passed directly to Motion's `transition` prop:
 
 ```tsx
-const p = useDialKit('Card', {
-  spring: { type: 'spring', visualDuration: 0.5, bounce: 0.04 },
+const p = useDialKit("Card", {
+  spring: { type: "spring", visualDuration: 0.5, bounce: 0.04 },
   x: [0, -200, 200],
 });
 
-<motion.div animate={{ x: p.x }} transition={p.spring} />
+<motion.div animate={{ x: p.x }} transition={p.spring} />;
 ```
 
 **Returns:** `SpringConfig` (pass directly to Motion)
@@ -324,15 +341,19 @@ const p = useDialKit('Card', {
 ### Action
 
 ```tsx
-const p = useDialKit('Controls', {
-  shuffle: { type: 'action' },
-  reset: { type: 'action', label: 'Reset All' },
-}, {
-  onAction: (path) => {
-    if (path === 'shuffle') shuffleItems();
-    if (path === 'reset') resetToDefaults();
+const p = useDialKit(
+  "Controls",
+  {
+    shuffle: { type: "action" },
+    reset: { type: "action", label: "Reset All" },
   },
-});
+  {
+    onAction: (path) => {
+      if (path === "shuffle") shuffleItems();
+      if (path === "reset") resetToDefaults();
+    },
+  },
+);
 ```
 
 Action buttons trigger callbacks without storing any value. The `label` defaults to the formatted key name (camelCase becomes Title Case). Multiple adjacent actions are grouped vertically.
@@ -369,8 +390,8 @@ DialKit also supports dynamic config updates. If your config shape, defaults, op
 Dynamic configs work with both inline objects and memoized configs — no special consumer action needed:
 
 ```tsx
-const values = useDialKit('Controls', {
-  style: { type: 'select', options: dynamicOptions },
+const values = useDialKit("Controls", {
+  style: { type: "select", options: dynamicOptions },
 });
 ```
 
@@ -381,7 +402,7 @@ const values = useDialKit('Controls', {
 Panels are open by default. Pass `collapsed: true` to start one collapsed:
 
 ```tsx
-const params = useDialKit('Stage', config, { id: 'stage', collapsed: true });
+const params = useDialKit("Stage", config, { id: "stage", collapsed: true });
 ```
 
 The same option exists on `createDialKit` in the Solid, Svelte, and Vue adapters.
@@ -389,19 +410,19 @@ The same option exists on `createDialKit` in the Solid, Svelte, and Vue adapters
 Open state lives in `DialStore`, so you can drive it from anywhere:
 
 ```tsx
-import { DialStore } from 'dialkit';
+import { DialStore } from "dialkit";
 
-DialStore.setPanelOpen('stage', false);   // collapse
-DialStore.setPanelOpen('stage', true);    // expand
-DialStore.togglePanelOpen('stage');
-DialStore.isPanelOpen('stage');           // boolean
+DialStore.setPanelOpen("stage", false); // collapse
+DialStore.setPanelOpen("stage", true); // expand
+DialStore.togglePanelOpen("stage");
+DialStore.isPanelOpen("stage"); // boolean
 ```
 
 These take the panel id — the `id` you passed to `useDialKit`, or the generated
 `${name}-${n}` when you didn't.
 
 Open state is in-memory only. It is never persisted, so a reload returns every
-panel to its configured default. To start a *folder* inside a panel collapsed,
+panel to its configured default. To start a _folder_ inside a panel collapsed,
 use the `_collapsed` config key described above.
 
 ---
@@ -412,14 +433,14 @@ use the `_collapsed` config key described above.
 <DialRoot position="top-right" />
 ```
 
-| Prop | Type | Default |
-|------|------|---------|
-| `position` | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'` |
-| `defaultOpen` | `boolean` | `true` |
-| `mode` | `'popover' \| 'inline'` | `'popover'` |
-| `theme` | `'system' \| 'light' \| 'dark'` | `'system'` |
-| `productionEnabled` | `boolean` | `false` in production, `true` otherwise |
-| `onOpenChange` | `(open: boolean) => void` | `undefined` |
+| Prop                | Type                                                           | Default                                 |
+| ------------------- | -------------------------------------------------------------- | --------------------------------------- |
+| `position`          | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'`                           |
+| `defaultOpen`       | `boolean`                                                      | `true`                                  |
+| `mode`              | `'popover' \| 'inline'`                                        | `'popover'`                             |
+| `theme`             | `'system' \| 'light' \| 'dark'`                                | `'system'`                              |
+| `productionEnabled` | `boolean`                                                      | `false` in production, `true` otherwise |
+| `onOpenChange`      | `(open: boolean) => void`                                      | `undefined`                             |
 
 Mount once at your app root. In the default `popover` mode, the panel renders via a portal on `document.body`. It collapses to a small icon button and expands to 280px wide on click.
 
@@ -429,19 +450,24 @@ If multiple `useDialKit` calls are registered under the same root, DialKit rende
 
 ```tsx
 function PhotoStack() {
-  const photo = useDialKit('Photo Stack', {
+  const photo = useDialKit("Photo Stack", {
     blur: [12, 0, 40],
     scale: [1, 0.5, 2],
   });
 
-  const stage = useDialKit('Stage', {
+  const stage = useDialKit("Stage", {
     pagePadding: [40, 16, 96],
-    background: '#ffffff',
+    background: "#ffffff",
   });
 
   return (
     <div style={{ padding: stage.pagePadding, background: stage.background }}>
-      <img style={{ filter: `blur(${photo.blur}px)`, transform: `scale(${photo.scale})` }} />
+      <img
+        style={{
+          filter: `blur(${photo.blur}px)`,
+          transform: `scale(${photo.scale})`,
+        }}
+      />
     </div>
   );
 }
@@ -453,9 +479,9 @@ Use `onOpenChange` when you need to persist whether the floating panel is open o
 
 ```tsx
 <DialRoot
-  defaultOpen={localStorage.getItem('dialkit-open') !== '0'}
+  defaultOpen={localStorage.getItem("dialkit-open") !== "0"}
   onOpenChange={(open) => {
-    localStorage.setItem('dialkit-open', open ? '1' : '0');
+    localStorage.setItem("dialkit-open", open ? "1" : "0");
   }}
 />
 ```
@@ -475,20 +501,23 @@ In popover mode, the collapsed panel bubble can be dragged to any position on th
 Use `mode="inline"` to render DialKit directly in your layout instead of as a floating popover. The panel fills its container and scrolls internally, which is useful for embedding in a sidebar or resizable panel. Inline mode works across all frameworks:
 
 **React:**
+
 ```tsx
-<aside style={{ width: 300, height: '100vh', overflow: 'hidden' }}>
+<aside style={{ width: 300, height: "100vh", overflow: "hidden" }}>
   <DialRoot mode="inline" />
 </aside>
 ```
 
 **Solid:**
+
 ```tsx
-<aside style={{ width: '300px', height: '100vh', overflow: 'hidden' }}>
+<aside style={{ width: "300px", height: "100vh", overflow: "hidden" }}>
   <DialRoot mode="inline" />
 </aside>
 ```
 
 **Svelte:**
+
 ```svelte
 <aside style:width="300px" style:height="100vh" style:overflow="hidden">
   <DialRoot mode="inline" />
@@ -513,63 +542,67 @@ When the panel is open, the toolbar provides:
 Assign keyboard shortcuts to controls so you can adjust values without touching the panel. Pass a `shortcuts` map in the options object:
 
 ```tsx
-const p = useDialKit('Card', {
-  blur: [24, 0, 100],
-  scale: 1.2,
-  opacity: [1, 0, 1],
-  borderRadius: [16, 0, 64],
-  darkMode: true,
-  shadow: {
-    blur: [10, 0, 50],
+const p = useDialKit(
+  "Card",
+  {
+    blur: [24, 0, 100],
+    scale: 1.2,
+    opacity: [1, 0, 1],
+    borderRadius: [16, 0, 64],
+    darkMode: true,
+    shadow: {
+      blur: [10, 0, 50],
+    },
   },
-}, {
-  shortcuts: {
-    blur:          { key: 'b', mode: 'fine' },                          // B+Scroll
-    scale:         { key: 's', interaction: 'drag', mode: 'coarse' },   // S+Drag
-    opacity:       { key: 'o', interaction: 'move' },                   // O+Move
-    borderRadius:  { interaction: 'scroll-only' },                      // Scroll (no key)
-    darkMode:      { key: 'm' },                                        // press M
-    'shadow.blur': { key: 'd', mode: 'fine' },                          // D+Scroll
+  {
+    shortcuts: {
+      blur: { key: "b", mode: "fine" }, // B+Scroll
+      scale: { key: "s", interaction: "drag", mode: "coarse" }, // S+Drag
+      opacity: { key: "o", interaction: "move" }, // O+Move
+      borderRadius: { interaction: "scroll-only" }, // Scroll (no key)
+      darkMode: { key: "m" }, // press M
+      "shadow.blur": { key: "d", mode: "fine" }, // D+Scroll
+    },
   },
-});
+);
 ```
 
 ### ShortcutConfig
 
 ```tsx
 type ShortcutConfig = {
-  key?: string;                                       // trigger key (e.g. 'b', 's') — optional for scroll-only
-  modifier?: 'alt' | 'shift' | 'meta';               // optional modifier key
-  mode?: 'fine' | 'normal' | 'coarse';               // precision level (default: 'normal')
-  interaction?: 'scroll' | 'drag' | 'move' | 'scroll-only'; // input method (default: 'scroll')
+  key?: string; // trigger key (e.g. 'b', 's') — optional for scroll-only
+  modifier?: "alt" | "shift" | "meta"; // optional modifier key
+  mode?: "fine" | "normal" | "coarse"; // precision level (default: 'normal')
+  interaction?: "scroll" | "drag" | "move" | "scroll-only"; // input method (default: 'scroll')
 };
 ```
 
 ### Interaction types
 
-| Interaction | Description | Example pill |
-|-------------|-------------|-------------|
-| `scroll` | Hold key + scroll wheel to adjust (default) | `B+Scroll` |
-| `drag` | Hold key + click and drag horizontally | `S+Drag` |
-| `move` | Hold key + move mouse (no click needed) | `O+Move` |
-| `scroll-only` | Just scroll anywhere, no key needed | `Scroll` |
+| Interaction   | Description                                 | Example pill |
+| ------------- | ------------------------------------------- | ------------ |
+| `scroll`      | Hold key + scroll wheel to adjust (default) | `B+Scroll`   |
+| `drag`        | Hold key + click and drag horizontally      | `S+Drag`     |
+| `move`        | Hold key + move mouse (no click needed)     | `O+Move`     |
+| `scroll-only` | Just scroll anywhere, no key needed         | `Scroll`     |
 
 ### Supported controls
 
-| Control | Interactions | Description |
-|---------|-------------|-------------|
+| Control    | Interactions                            | Description                           |
+| ---------- | --------------------------------------- | ------------------------------------- |
 | **Slider** | `scroll`, `drag`, `move`, `scroll-only` | Adjust value with chosen input method |
-| **Toggle** | key press | Press the assigned key to flip on/off |
+| **Toggle** | key press                               | Press the assigned key to flip on/off |
 
 ### Precision modes
 
 For sliders, the `mode` controls how much each scroll tick or drag pixel changes the value:
 
-| Mode | Step multiplier | Use case |
-|------|----------------|----------|
-| `fine` | step &divide; 10 | Precision tweaking |
-| `normal` | step &times; 1 | Default behavior |
-| `coarse` | step &times; 10 | Big sweeps |
+| Mode     | Step multiplier  | Use case           |
+| -------- | ---------------- | ------------------ |
+| `fine`   | step &divide; 10 | Precision tweaking |
+| `normal` | step &times; 1   | Default behavior   |
+| `coarse` | step &times; 10  | Big sweeps         |
 
 ### Nested paths
 
@@ -593,50 +626,62 @@ Shortcuts are automatically disabled when a text input is focused.
 ## Full Example
 
 ```tsx
-import { useDialKit } from 'dialkit';
-import { motion } from 'motion/react';
+import { useDialKit } from "dialkit";
+import { motion } from "motion/react";
 
 function PhotoStack() {
-  const p = useDialKit('Photo Stack', {
-    // Text inputs
-    title: 'Japan',
-    subtitle: { type: 'text', default: 'December 2025', placeholder: 'Enter subtitle...' },
+  const p = useDialKit(
+    "Photo Stack",
+    {
+      // Text inputs
+      title: "Japan",
+      subtitle: {
+        type: "text",
+        default: "December 2025",
+        placeholder: "Enter subtitle...",
+      },
 
-    // Color pickers
-    accentColor: '#c41e3a',
-    shadowTint: { type: 'color', default: '#000000' },
+      // Color pickers
+      accentColor: "#c41e3a",
+      shadowTint: { type: "color", default: "#000000" },
 
-    // Select dropdown
-    layout: { type: 'select', options: ['stack', 'fan', 'grid'], default: 'stack' },
+      // Select dropdown
+      layout: {
+        type: "select",
+        options: ["stack", "fan", "grid"],
+        default: "stack",
+      },
 
-    // Grouped sliders in a folder
-    backPhoto: {
-      offsetX: [239, 0, 400],
-      offsetY: [0, 0, 150],
-      scale: [0.7, 0.5, 0.95],
-      overlayOpacity: [0.6, 0, 1],
+      // Grouped sliders in a folder
+      backPhoto: {
+        offsetX: [239, 0, 400],
+        offsetY: [0, 0, 150],
+        scale: [0.7, 0.5, 0.95],
+        overlayOpacity: [0.6, 0, 1],
+      },
+
+      // Spring config for Motion
+      transitionSpring: { type: "spring", visualDuration: 0.5, bounce: 0.04 },
+
+      // Toggle
+      darkMode: false,
+
+      // Action buttons
+      next: { type: "action" },
+      previous: { type: "action" },
     },
-
-    // Spring config for Motion
-    transitionSpring: { type: 'spring', visualDuration: 0.5, bounce: 0.04 },
-
-    // Toggle
-    darkMode: false,
-
-    // Action buttons
-    next: { type: 'action' },
-    previous: { type: 'action' },
-  }, {
-    shortcuts: {
-      'backPhoto.offsetX': { key: 'x', interaction: 'drag', mode: 'coarse' },
-      'backPhoto.scale': { key: 's', interaction: 'move', mode: 'fine' },
-      darkMode: { key: 'm' },
+    {
+      shortcuts: {
+        "backPhoto.offsetX": { key: "x", interaction: "drag", mode: "coarse" },
+        "backPhoto.scale": { key: "s", interaction: "move", mode: "fine" },
+        darkMode: { key: "m" },
+      },
+      onAction: (action) => {
+        if (action === "next") goNext();
+        if (action === "previous") goPrevious();
+      },
     },
-    onAction: (action) => {
-      if (action === 'next') goNext();
-      if (action === 'previous') goPrevious();
-    },
-  });
+  );
 
   return (
     <motion.div
@@ -662,19 +707,19 @@ The animation's structure stays in code. The timeline editor adjusts its propert
 Timeline is available in React, Solid, Svelte, and Vue. Every adapter uses the same framework-neutral timeline core and store, while lifecycle and rendering stay native to its framework.
 
 ```tsx
-import { useDialTimeline, DialTimeline } from 'dialkit';
-import 'dialkit/styles.css';
+import { useDialTimeline, DialTimeline } from "dialkit";
+import "dialkit/styles.css";
 
 function Hero() {
   const hero = useDialTimeline(
-    'Hero',
+    "Hero",
     {
       entrance: {
         at: 0,
         duration: 0.6,
         from: { y: 32, opacity: 0 },
         to: { y: 0, opacity: 1 },
-        transition: { type: 'spring', bounce: 0.2 },
+        transition: { type: "spring", bounce: 0.2 },
       },
       idle: {
         at: 0.8,
@@ -686,7 +731,7 @@ function Hero() {
         ],
       },
     },
-    { loop: { from: 0.8 } }
+    { loop: { from: 0.8 } },
   );
 
   const entrance = hero.entrance.current;
@@ -694,10 +739,12 @@ function Hero() {
 
   return (
     <>
-      <h1 style={{
-        opacity: entrance.opacity,
-        transform: `translateY(${entrance.y + idle.y}px)`,
-      }}>
+      <h1
+        style={{
+          opacity: entrance.opacity,
+          transform: `translateY(${entrance.y + idle.y}px)`,
+        }}
+      >
         Ship the moment.
       </h1>
       <DialTimeline />
@@ -710,12 +757,12 @@ Each named entry is a clip and appears as one row in the timeline. During author
 
 The framework entry points expose the same config, values, transport, and `<DialTimeline />` dock:
 
-| Framework | Import | Timeline function | Read returned values |
-|-----------|--------|-------------------|----------------------|
-| React | `dialkit` | `useDialTimeline` | `timeline.card.current` |
-| Solid | `dialkit/solid` | `createDialTimeline` | `timeline().card.current` |
-| Svelte 5 | `dialkit/svelte` | `createDialTimeline` | `timeline.card.current` |
-| Vue 3 | `dialkit/vue` | `useDialTimeline` | `timeline.value.card.current` in script; auto-unwrapped in templates |
+| Framework | Import           | Timeline function    | Read returned values                                                 |
+| --------- | ---------------- | -------------------- | -------------------------------------------------------------------- |
+| React     | `dialkit`        | `useDialTimeline`    | `timeline.card.current`                                              |
+| Solid     | `dialkit/solid`  | `createDialTimeline` | `timeline().card.current`                                            |
+| Svelte 5  | `dialkit/svelte` | `createDialTimeline` | `timeline.card.current`                                              |
+| Vue 3     | `dialkit/vue`    | `useDialTimeline`    | `timeline.value.card.current` in script; auto-unwrapped in templates |
 
 ### Timeline function
 
@@ -724,29 +771,29 @@ const tl = useDialTimeline(name, config, options?)
 // Solid/Svelte: createDialTimeline(name, config, options?)
 ```
 
-| Param | Type | Description |
-|-------|------|-------------|
-| `name` | `string` | Timeline title displayed in the dock |
-| `config` | `TimelineConfig` | Clip definitions plus an optional top-level `duration` |
-| `options.id` | `string` | Stable logical id, same semantics as `useDialKit` |
-| `options.persist` | `DialKitPersistOptions` | Persist timing edits to browser storage |
-| `options.autoplay` | `boolean` | Start playing on mount. Default `true` |
-| `options.loop` | `boolean \| { from: number }` | Wrap the playhead when it reaches the end (see [Looping](#looping)) |
+| Param              | Type                          | Description                                                         |
+| ------------------ | ----------------------------- | ------------------------------------------------------------------- |
+| `name`             | `string`                      | Timeline title displayed in the dock                                |
+| `config`           | `TimelineConfig`              | Clip definitions plus an optional top-level `duration`              |
+| `options.id`       | `string`                      | Stable logical id, same semantics as `useDialKit`                   |
+| `options.persist`  | `DialKitPersistOptions`       | Persist timing edits to browser storage                             |
+| `options.autoplay` | `boolean`                     | Start playing on mount. Default `true`                              |
+| `options.loop`     | `boolean \| { from: number }` | Wrap the playhead when it reaches the end (see [Looping](#looping)) |
 
 Clip timing lives in the same store as panel values, so presets, persistence, reset, and Copy all work on timing data with no extra wiring.
 
 The returned object combines the transport with one entry per clip:
 
 ```tsx
-tl.time        // playhead in seconds
-tl.playing     // boolean
-tl.duration    // timeline length in seconds
-tl.play()      // resume (restarts if parked at the end)
-tl.pause()
-tl.replay()    // seek to 0 and play
-tl.seek(1.2)   // move the playhead (pins the deterministic first-pass state)
+tl.time; // playhead in seconds
+tl.playing; // boolean
+tl.duration; // timeline length in seconds
+tl.play(); // resume (restarts if parked at the end)
+tl.pause();
+tl.replay(); // seek to 0 and play
+tl.seek(1.2); // move the playhead (pins the deterministic first-pass state)
 
-tl.headline    // TimelineClipValues for the "headline" clip
+tl.headline; // TimelineClipValues for the "headline" clip
 ```
 
 `time`, `playing`, `duration`, `play`, `pause`, `replay`, and `seek` are reserved — a clip with one of those names is skipped with a console warning.
@@ -774,7 +821,7 @@ card: {
 
 - **`from` / `to`** accept any normal DialKit leaf values — numbers, hex colors — and become editable controls in the clip's popover. Bare numbers get property-aware slider ranges (`x`/`y` ±100, `rotate` ±180, `scale` 0–2, `opacity` 0–1, and so on), expanded to include your actual endpoints.
 - **`transition`** is a spring or easing config, exactly as in the panel's spring editor. Clips with `from`/`to` and no `transition` animate with a default spring (`{ type: 'spring', bounce: 0.2 }`).
-- **The bar owns the duration.** Time-based springs and easings stretch to the bar: resize the clip and the curve retimes. Physics springs (`stiffness`/`damping`/`mass`) work the other way — the duration is *derived* from their settle time, the bar shows `~0.62s`, and it can't be resized (change the physics instead).
+- **The bar owns the duration.** Time-based springs and easings stretch to the bar: resize the clip and the curve retimes. Physics springs (`stiffness`/`damping`/`mass`) work the other way — the duration is _derived_ from their settle time, the bar shows `~0.62s`, and it can't be resized (change the physics instead).
 - **`duration` may be omitted** — it defaults to the easing's duration or the spring's settle time; a `from`/`to` clip with no `transition` gets the default spring's settle time.
 
 Config mistakes warn in the console instead of failing silently: an entry missing `at`, conflicting clip shapes (`steps` + `to`, `props` + `from`), or a sequence property with no starting value.
@@ -792,21 +839,21 @@ shine: { at: 2.7, duration: 0.7 },
 
 Each clip on the returned object is a `TimelineClipValues`:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `at` | `number` | Clip start in seconds — live, reflects dock edits |
-| `duration` | `number` | Effective duration — the bar length |
-| `loop` | `'off' \| 'repeat'` | Effective loop mode |
-| `started` | `boolean` | Playhead is at or past the clip start |
-| `active` | `boolean` | Playhead is inside the clip (any cycle, for looping clips) |
-| `done` | `boolean` | Playhead is past the clip end (past the timeline end, for looping clips) |
-| `progress` | `number` | 0–1 position within the clip — a sawtooth per cycle for looping clips |
-| `step` | `number` | Index of the leg under the playhead (sequence clips only) |
-| `from` / `to` | `object` | Resolved endpoint values (`to` is the final merged state for sequences) |
-| `animate` | `object` | `to` once the clip has started, `from` before |
-| `transition` | `TransitionConfig` | Motion-ready curve, duration driven by the bar (single-curve clips only) |
-| `css` | `TimelineClipCss` | `transitionDuration` + `transitionTimingFunction` (single-curve clips only) |
-| `current` | `object` | Values interpolated through the clip's curves at the playhead |
+| Field         | Type                | Description                                                                 |
+| ------------- | ------------------- | --------------------------------------------------------------------------- |
+| `at`          | `number`            | Clip start in seconds — live, reflects dock edits                           |
+| `duration`    | `number`            | Effective duration — the bar length                                         |
+| `loop`        | `'off' \| 'repeat'` | Effective loop mode                                                         |
+| `started`     | `boolean`           | Playhead is at or past the clip start                                       |
+| `active`      | `boolean`           | Playhead is inside the clip (any cycle, for looping clips)                  |
+| `done`        | `boolean`           | Playhead is past the clip end (past the timeline end, for looping clips)    |
+| `progress`    | `number`            | 0–1 position within the clip — a sawtooth per cycle for looping clips       |
+| `step`        | `number`            | Index of the leg under the playhead (sequence clips only)                   |
+| `from` / `to` | `object`            | Resolved endpoint values (`to` is the final merged state for sequences)     |
+| `animate`     | `object`            | `to` once the clip has started, `from` before                               |
+| `transition`  | `TransitionConfig`  | Motion-ready curve, duration driven by the bar (single-curve clips only)    |
+| `css`         | `TimelineClipCss`   | `transitionDuration` + `transitionTimingFunction` (single-curve clips only) |
+| `current`     | `object`            | Values interpolated through the clip's curves at the playhead               |
 
 ### Recommended workflow: preview, copy, replace
 
@@ -825,10 +872,12 @@ There are three ways to bind a clip while authoring:
 **1. `current` — recommended for tuning.** Bind styles directly; the element sits at DialKit's sampled state at all times, giving you true scrubbing. DialKit remains the renderer until you replace this binding with your production animation.
 
 ```tsx
-<div style={{
-  opacity: tl.card.current.opacity,
-  transform: `translateY(${tl.card.current.y}px) scale(${tl.card.current.scale})`,
-}} />
+<div
+  style={{
+    opacity: tl.card.current.opacity,
+    transform: `translateY(${tl.card.current.y}px) scale(${tl.card.current.scale})`,
+  }}
+/>
 ```
 
 **2. `animate` + `transition` — real Motion during authoring.** The clip start flips `animate` from `from` to `to`, so Motion runs the actual curve. The tradeoff is that timeline scrubbing snaps between endpoints instead of showing intermediate states.
@@ -840,12 +889,14 @@ There are three ways to bind a clip while authoring:
 **3. `animate` + `css` — native CSS during authoring.** Same endpoint flip, using a CSS transition. Easing curves map exactly; springs are approximated with an overshoot bezier, and scrubbing still snaps between endpoints.
 
 ```tsx
-<div style={{
-  opacity: tl.card.animate.opacity,
-  transform: `translateY(${tl.card.animate.y}px)`,
-  transitionProperty: 'transform, opacity',
-  ...tl.card.css,
-}} />
+<div
+  style={{
+    opacity: tl.card.animate.opacity,
+    transform: `translateY(${tl.card.animate.y}px)`,
+    transitionProperty: "transform, opacity",
+    ...tl.card.css,
+  }}
+/>
 ```
 
 ### Sequences — `steps`
@@ -874,7 +925,7 @@ path: {
 
 ### Property tracks — `props`
 
-When one element's properties need *independent* timing — different durations, different curves, offset phases — give each property a full track:
+When one element's properties need _independent_ timing — different durations, different curves, offset phases — give each property a full track:
 
 ```tsx
 float: {
@@ -911,15 +962,15 @@ Each track is a mini-clip: its own `from`/`to` or `steps`, `duration`, `transiti
 Nesting clips one level under a key groups them into a collapsible layer in the dock. Purely presentational — values nest the same way:
 
 ```tsx
-const tl = useDialTimeline('Compound', {
+const tl = useDialTimeline("Compound", {
   circle: {
-    path:  { at: 0, /* ... */ },
-    float: { at: 0, /* ... */ },
+    path: { at: 0 /* ... */ },
+    float: { at: 0 /* ... */ },
   },
 });
 
-tl.circle.path.current
-tl.circle.float.current
+tl.circle.path.current;
+tl.circle.float.current;
 ```
 
 ### Looping
@@ -928,11 +979,11 @@ There are two loop controls, and they compose:
 
 **Clip loop** — `loop: true` on a clip repeats its cycle from `at` until the timeline ends. The bar is one cycle, so dragging it longer slows the loop. Looping is code-defined rather than editable in the dock. There is no mirror mode — a loop that should return home (a bob, a pulse) is a sequence whose last leg lands back on the starting values, which also puts the loop seam at a natural zero-velocity point.
 
-**Timeline loop** — the `loop` option wraps the *playhead*:
+**Timeline loop** — the `loop` option wraps the _playhead_:
 
 ```tsx
-useDialTimeline('Hero', config, { loop: true });           // wrap to 0
-useDialTimeline('Hero', config, { loop: { from: 1.4 } });  // wrap to 1.4s
+useDialTimeline("Hero", config, { loop: true }); // wrap to 0
+useDialTimeline("Hero", config, { loop: { from: 1.4 } }); // wrap to 1.4s
 ```
 
 `{ from }` is the intro-then-idle pattern: clips before that time play exactly once, and looping clips inside the region keep cycling with continuous phase — no snap at the wrap. Scrubbing always pins the deterministic first-pass state.
@@ -940,9 +991,9 @@ useDialTimeline('Hero', config, { loop: { from: 1.4 } });  // wrap to 1.4s
 **Event-driven timelines** — pass `autoplay: false` and drive the transport from your app. The dock and your code share the same clock: click your real button, watch the playhead run, scrub back, tune, click again.
 
 ```tsx
-const toast = useDialTimeline('Toast', config, { autoplay: false });
+const toast = useDialTimeline("Toast", config, { autoplay: false });
 
-<button onClick={() => toast.replay()}>Save changes</button>
+<button onClick={() => toast.replay()}>Save changes</button>;
 ```
 
 ### Timeline duration
@@ -950,9 +1001,9 @@ const toast = useDialTimeline('Toast', config, { autoplay: false });
 The top-level `duration` is the minimum editing window. Omit it and DialKit initially infers an exact fit to the last clip's end. If a live edit—such as switching to a longer physics spring—would move content past that boundary, DialKit extends the timeline automatically. Set `duration` explicitly when you want deliberate slack; authored content is never clipped to fit it.
 
 ```tsx
-const tl = useDialTimeline('Hero', {
-  duration: 4,          // seconds; minimum window, inferred when omitted
-  headline: { at: 0.45, /* ... */ },
+const tl = useDialTimeline("Hero", {
+  duration: 4, // seconds; minimum window, inferred when omitted
+  headline: { at: 0.45 /* ... */ },
 });
 ```
 
@@ -964,14 +1015,14 @@ Mount once, anywhere. The dock renders fixed to the bottom of the screen via a p
 <DialTimeline theme="dark" />
 ```
 
-| Prop | Type | Default |
-|------|------|---------|
-| `theme` | `'system' \| 'light' \| 'dark'` | `'system'` |
-| `defaultVisible` | `boolean` | `true` |
-| `visible` | `boolean` | uncontrolled |
-| `onVisibilityChange` | `(visible: boolean) => void` | `undefined` |
-| `defaultOpen` | `boolean` | `true` |
-| `productionEnabled` | `boolean` | `false` in production, `true` otherwise |
+| Prop                 | Type                            | Default                                 |
+| -------------------- | ------------------------------- | --------------------------------------- |
+| `theme`              | `'system' \| 'light' \| 'dark'` | `'system'`                              |
+| `defaultVisible`     | `boolean`                       | `true`                                  |
+| `visible`            | `boolean`                       | uncontrolled                            |
+| `onVisibilityChange` | `(visible: boolean) => void`    | `undefined`                             |
+| `defaultOpen`        | `boolean`                       | `true`                                  |
+| `productionEnabled`  | `boolean`                       | `false` in production, `true` otherwise |
 
 Each section's toolbar has **Play/Pause**, **Add Version**, a version selector, **Copy**, and a collapse chevron. The collapsed toolbar stays playable and keeps its full-range overview scrubber, so you can inspect the animation without opening the detailed tracks.
 
@@ -1007,8 +1058,8 @@ npm install dialkit solid-js
 
 ```tsx
 // App.tsx
-import { DialRoot } from 'dialkit/solid';
-import 'dialkit/styles.css';
+import { DialRoot } from "dialkit/solid";
+import "dialkit/styles.css";
 
 export default function App() {
   return (
@@ -1022,23 +1073,25 @@ export default function App() {
 
 ```tsx
 // component.tsx
-import { createDialKit } from 'dialkit/solid';
+import { createDialKit } from "dialkit/solid";
 
 function Card() {
-  const params = createDialKit('Card', {
+  const params = createDialKit("Card", {
     blur: [24, 0, 100],
     scale: 1.2,
-    color: '#ff5500',
+    color: "#ff5500",
     visible: true,
   });
 
   return (
-    <div style={{
-      filter: `blur(${params().blur}px)`,
-      transform: `scale(${params().scale})`,
-      color: params().color,
-      opacity: params().visible ? 1 : 0,
-    }}>
+    <div
+      style={{
+        filter: `blur(${params().blur}px)`,
+        transform: `scale(${params().scale})`,
+        color: params().color,
+        opacity: params().visible ? 1 : 0,
+      }}
+    >
       ...
     </div>
   );
@@ -1050,10 +1103,10 @@ function Card() {
 Solid timelines use the same accessor shape:
 
 ```tsx
-import { createDialTimeline, DialTimeline } from 'dialkit/solid';
+import { createDialTimeline, DialTimeline } from "dialkit/solid";
 
 function Hero() {
-  const timeline = createDialTimeline('Hero', {
+  const timeline = createDialTimeline("Hero", {
     entrance: {
       at: 0,
       duration: 0.6,
@@ -1062,19 +1115,21 @@ function Hero() {
     },
   });
 
-  return <>
-    <h1 style={{ opacity: timeline().entrance.current.opacity }}>Ship it.</h1>
-    <DialTimeline />
-  </>;
+  return (
+    <>
+      <h1 style={{ opacity: timeline().entrance.current.opacity }}>Ship it.</h1>
+      <DialTimeline />
+    </>
+  );
 }
 ```
 
 Use `createDialKitController` when Solid code needs to update values:
 
 ```tsx
-import { createDialKitController } from 'dialkit/solid';
+import { createDialKitController } from "dialkit/solid";
 
-const dial = createDialKitController('Card', {
+const dial = createDialKitController("Card", {
   blur: [24, 0, 100],
   shadow: { radius: [16, 0, 64] },
 });
@@ -1180,48 +1235,54 @@ npm install dialkit motion-v vue
 
 ```ts
 // main.ts
-import { createApp } from 'vue';
-import { DialRoot } from 'dialkit/vue';
-import 'dialkit/styles.css';
-import App from './App.vue';
+import { createApp } from "vue";
+import { DialRoot } from "dialkit/vue";
+import "dialkit/styles.css";
+import App from "./App.vue";
 
 const app = createApp(App);
-app.mount('#app');
+app.mount("#app");
 ```
 
 ```vue
 <!-- App.vue -->
 <script setup>
-import { DialRoot } from 'dialkit/vue';
-import Card from './Card.vue';
+import { DialRoot } from "dialkit/vue";
+import Card from "./Card.vue";
 </script>
 
 <template>
   <Card />
-  <DialRoot @open-change="(open) => localStorage.setItem('dialkit-open', open ? '1' : '0')" />
+  <DialRoot
+    @open-change="
+      (open) => localStorage.setItem('dialkit-open', open ? '1' : '0')
+    "
+  />
 </template>
 ```
 
 ```vue
 <!-- Card.vue -->
 <script setup>
-import { useDialKit } from 'dialkit/vue';
+import { useDialKit } from "dialkit/vue";
 
-const params = useDialKit('Card', {
+const params = useDialKit("Card", {
   blur: [24, 0, 100],
   scale: 1.2,
-  color: '#ff5500',
+  color: "#ff5500",
   visible: true,
 });
 </script>
 
 <template>
-  <div :style="{
-    filter: `blur(${params.blur}px)`,
-    transform: `scale(${params.scale})`,
-    color: params.color,
-    opacity: params.visible ? 1 : 0,
-  }">
+  <div
+    :style="{
+      filter: `blur(${params.blur}px)`,
+      transform: `scale(${params.scale})`,
+      color: params.color,
+      opacity: params.visible ? 1 : 0,
+    }"
+  >
     ...
   </div>
 </template>
@@ -1233,9 +1294,9 @@ Vue timelines return a computed ref, which templates unwrap automatically:
 
 ```vue
 <script setup>
-import { useDialTimeline, DialTimeline } from 'dialkit/vue';
+import { useDialTimeline, DialTimeline } from "dialkit/vue";
 
-const timeline = useDialTimeline('Hero', {
+const timeline = useDialTimeline("Hero", {
   entrance: {
     at: 0,
     duration: 0.6,
@@ -1255,18 +1316,25 @@ Use `useDialKitController` when Vue code needs to update values:
 
 ```vue
 <script setup>
-import { useDialKitController } from 'dialkit/vue';
+import { useDialKitController } from "dialkit/vue";
 
-const { values, setValues, resetValues } = useDialKitController('Card', {
+const { values, setValues, resetValues } = useDialKitController("Card", {
   blur: [24, 0, 100],
   shadow: { radius: [16, 0, 64] },
 });
 </script>
 
 <template>
-  <button @click="setValues({ blur: 48, shadow: { radius: 28 } })">Apply preset</button>
+  <button @click="setValues({ blur: 48, shadow: { radius: 28 } })">
+    Apply preset
+  </button>
   <button @click="resetValues()">Reset</button>
-  <div :style="{ filter: `blur(${values.blur}px)`, borderRadius: `${values.shadow.radius}px` }" />
+  <div
+    :style="{
+      filter: `blur(${values.blur}px)`,
+      borderRadius: `${values.shadow.radius}px`,
+    }"
+  />
 </template>
 ```
 
@@ -1295,7 +1363,7 @@ import type {
   ControlMeta,
   PanelConfig,
   Preset,
-} from 'dialkit';
+} from "dialkit";
 ```
 
 Timeline types are exported as well:
@@ -1316,7 +1384,7 @@ import type {
   DialTimelineValues,
   UseDialTimelineOptions,
   DialTimelineProps,
-} from 'dialkit';
+} from "dialkit";
 ```
 
 Return values are fully typed: `params.blur` infers as `number`, `params.color` as `string`, `params.spring` as `SpringConfig`, `params.shadow` as a nested object, etc. Timeline values are typed from the config shape too — `tl.card.current.y` infers as `number`, and `step` only exists on sequence clips.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ npm install dialkit motion
 
 ```tsx
 // layout.tsx
-import { DialRoot } from "dialkit";
-import "dialkit/styles.css";
+import { DialRoot } from 'dialkit';
+import 'dialkit/styles.css';
 
 export default function Layout({ children }) {
   return (
@@ -37,25 +37,23 @@ export default function Layout({ children }) {
 
 ```tsx
 // component.tsx
-import { useDialKit } from "dialkit";
+import { useDialKit } from 'dialkit';
 
 function Card() {
-  const p = useDialKit("Card", {
+  const p = useDialKit('Card', {
     blur: [24, 0, 100],
     scale: 1.2,
-    color: "#ff5500",
+    color: '#ff5500',
     visible: true,
   });
 
   return (
-    <div
-      style={{
-        filter: `blur(${p.blur}px)`,
-        transform: `scale(${p.scale})`,
-        color: p.color,
-        opacity: p.visible ? 1 : 0,
-      }}
-    >
+    <div style={{
+      filter: `blur(${p.blur}px)`,
+      transform: `scale(${p.scale})`,
+      color: p.color,
+      opacity: p.visible ? 1 : 0,
+    }}>
       ...
     </div>
   );
@@ -70,15 +68,15 @@ function Card() {
 const params = useDialKit(name, config, options?)
 ```
 
-| Param               | Type                             | Description                                                                     |
-| ------------------- | -------------------------------- | ------------------------------------------------------------------------------- |
-| `name`              | `string`                         | Panel title displayed in the UI                                                 |
-| `config`            | `DialConfig`                     | Parameter definitions (see Control Types below)                                 |
-| `options.id`        | `string`                         | Stable logical id for sharing values across remounts/pages                      |
-| `options.persist`   | `DialKitPersistOptions`          | Persist values to browser storage                                               |
-| `options.collapsed` | `boolean`                        | Start this panel collapsed (see [Panel open state](#panel-open-state))          |
-| `options.onAction`  | `(path: string) => void`         | Callback when action buttons are clicked                                        |
+| Param | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Panel title displayed in the UI |
+| `config` | `DialConfig` | Parameter definitions (see Control Types below) |
+| `options.id` | `string` | Stable logical id for sharing values across remounts/pages |
+| `options.persist` | `DialKitPersistOptions` | Persist values to browser storage |
+| `options.onAction` | `(path: string) => void` | Callback when action buttons are clicked |
 | `options.shortcuts` | `Record<string, ShortcutConfig>` | Keyboard shortcuts for controls (see [Keyboard Shortcuts](#keyboard-shortcuts)) |
+| `options.collapsed` | `boolean` | Start this panel collapsed (see [Panel open state](#panel-open-state)) |
 
 Returns a fully typed object matching your config shape with live values. Updating a control in the UI immediately updates the returned values.
 
@@ -90,21 +88,17 @@ By default, a DialKit panel is tied to the lifecycle of the component that calls
 
 ```tsx
 // dials/useOnboardingDials.ts
-import { useDialKit } from "dialkit";
+import { useDialKit } from 'dialkit';
 
 export function useOnboardingDials() {
-  return useDialKit(
-    "Onboarding",
-    {
-      name: { type: "text", default: "Avery", placeholder: "Name" },
-      avatarScale: [1, 0.6, 1.6, 0.01],
-      accent: { type: "color", default: "#6C5CE7" },
-    },
-    {
-      id: "onboarding",
-      persist: true,
-    },
-  );
+  return useDialKit('Onboarding', {
+    name: { type: 'text', default: 'Avery', placeholder: 'Name' },
+    avatarScale: [1, 0.6, 1.6, 0.01],
+    accent: { type: 'color', default: '#6C5CE7' },
+  }, {
+    id: 'onboarding',
+    persist: true,
+  });
 }
 ```
 
@@ -114,7 +108,7 @@ Use that helper anywhere the shared values are needed:
 function PageTwo() {
   const onboarding = useOnboardingDials();
 
-  const page = useDialKit("Page Two", {
+  const page = useDialKit('Page Two', {
     cardRadius: [16, 0, 64],
   });
 
@@ -133,11 +127,11 @@ When `PageTwo` is mounted, the single `<DialRoot />` shows both `Onboarding` and
 `persist: true` stores values, presets, and the active preset in `localStorage` using `dialkit:${id}` as the key. Use the object form to customize storage:
 
 ```tsx
-useDialKit("Onboarding", config, {
-  id: "onboarding",
+useDialKit('Onboarding', config, {
+  id: 'onboarding',
   persist: {
-    key: "my-app:onboarding-dials",
-    storage: "sessionStorage",
+    key: 'my-app:onboarding-dials',
+    storage: 'sessionStorage',
     presets: false,
   },
 });
@@ -152,13 +146,13 @@ The `id` string has no special format; it only needs to be reused wherever you w
 Use the controller API when your app code also needs to update DialKit values, such as reset buttons, URL sync, or app-defined preset buttons.
 
 ```tsx
-import { useDialKitController } from "dialkit";
+import { useDialKitController } from 'dialkit';
 
 function Card() {
-  const dial = useDialKitController("Card", {
+  const dial = useDialKitController('Card', {
     blur: [24, 0, 100],
     scale: 1.2,
-    color: "#ff5500",
+    color: '#ff5500',
     visible: true,
     shadow: {
       radius: [16, 0, 64],
@@ -167,28 +161,22 @@ function Card() {
 
   return (
     <>
-      <button
-        onClick={() =>
-          dial.setValues({
-            blur: 48,
-            scale: 1,
-            shadow: { radius: 28 },
-          })
-        }
-      >
+      <button onClick={() => dial.setValues({
+        blur: 48,
+        scale: 1,
+        shadow: { radius: 28 },
+      })}>
         Apply preset
       </button>
       <button onClick={() => dial.resetValues()}>Reset</button>
 
-      <div
-        style={{
-          filter: `blur(${dial.values.blur}px)`,
-          transform: `scale(${dial.values.scale})`,
-          color: dial.values.color,
-          opacity: dial.values.visible ? 1 : 0,
-          borderRadius: dial.values.shadow.radius,
-        }}
-      >
+      <div style={{
+        filter: `blur(${dial.values.blur}px)`,
+        transform: `scale(${dial.values.scale})`,
+        color: dial.values.color,
+        opacity: dial.values.visible ? 1 : 0,
+        borderRadius: dial.values.shadow.radius,
+      }}>
         ...
       </div>
     </>
@@ -198,13 +186,13 @@ function Card() {
 
 Controller methods:
 
-| Method                  | Description                                                       |
-| ----------------------- | ----------------------------------------------------------------- |
-| `values`                | The same live resolved values returned by `useDialKit`            |
-| `setValue(path, value)` | Updates one control by dot path, like `'shadow.radius'`           |
-| `setValues(values)`     | Updates multiple controls with a typed nested partial object      |
-| `resetValues()`         | Restores the current config defaults and clears the active preset |
-| `getValues()`           | Reads the latest resolved values outside render callbacks         |
+| Method | Description |
+|--------|-------------|
+| `values` | The same live resolved values returned by `useDialKit` |
+| `setValue(path, value)` | Updates one control by dot path, like `'shadow.radius'` |
+| `setValues(values)` | Updates multiple controls with a typed nested partial object |
+| `resetValues()` | Restores the current config defaults and clears the active preset |
+| `getValues()` | Reads the latest resolved values outside render callbacks |
 
 Programmatic updates use the same state as panel edits. If a saved preset is active, updates are saved into that preset; otherwise they update the base "Version 1" values. Action controls are triggers, so they are not set by `setValues`.
 
@@ -217,33 +205,28 @@ Programmatic updates use the same state as panel edits. If a saved preset is act
 Numbers create sliders. There are three ways to define them:
 
 **Explicit range** — `[default, min, max]`:
-
 ```tsx
-blur: [24, 0, 100];
+blur: [24, 0, 100]
 ```
 
 **Explicit range + step** — `[default, min, max, step]`:
-
 ```tsx
-blur: [24, 0, 100, 5]; // snaps in increments of 5
+blur: [24, 0, 100, 5]    // snaps in increments of 5
 ```
-
 When `step` is omitted, it's inferred from the range (see table below).
 
 **Auto-inferred** — bare number:
-
 ```tsx
-scale: 1.2;
+scale: 1.2
 ```
-
 A single number auto-infers a reasonable min, max, and step:
 
-| Value range | Inferred min/max     | Step |
-| ----------- | -------------------- | ---- |
-| 0–1         | 0 to 1               | 0.01 |
-| 0–10        | 0 to value &times; 3 | 0.1  |
-| 0–100       | 0 to value &times; 3 | 1    |
-| 100+        | 0 to value &times; 3 | 10   |
+| Value range | Inferred min/max | Step |
+|-------------|-----------------|------|
+| 0–1 | 0 to 1 | 0.01 |
+| 0–10 | 0 to value &times; 3 | 0.1 |
+| 0–100 | 0 to value &times; 3 | 1 |
+| 100+ | 0 to value &times; 3 | 10 |
 
 **Returns:** `number`
 
@@ -252,8 +235,8 @@ Sliders support click-to-snap (with spring animation), drag with rubber-band ove
 ### Toggle
 
 ```tsx
-enabled: true;
-darkMode: false;
+enabled: true
+darkMode: false
 ```
 
 Booleans create an Off/On segmented control.
@@ -328,12 +311,12 @@ Creates a visual spring editor with a live animation curve preview. The editor s
 The returned config object is passed directly to Motion's `transition` prop:
 
 ```tsx
-const p = useDialKit("Card", {
-  spring: { type: "spring", visualDuration: 0.5, bounce: 0.04 },
+const p = useDialKit('Card', {
+  spring: { type: 'spring', visualDuration: 0.5, bounce: 0.04 },
   x: [0, -200, 200],
 });
 
-<motion.div animate={{ x: p.x }} transition={p.spring} />;
+<motion.div animate={{ x: p.x }} transition={p.spring} />
 ```
 
 **Returns:** `SpringConfig` (pass directly to Motion)
@@ -341,19 +324,15 @@ const p = useDialKit("Card", {
 ### Action
 
 ```tsx
-const p = useDialKit(
-  "Controls",
-  {
-    shuffle: { type: "action" },
-    reset: { type: "action", label: "Reset All" },
+const p = useDialKit('Controls', {
+  shuffle: { type: 'action' },
+  reset: { type: 'action', label: 'Reset All' },
+}, {
+  onAction: (path) => {
+    if (path === 'shuffle') shuffleItems();
+    if (path === 'reset') resetToDefaults();
   },
-  {
-    onAction: (path) => {
-      if (path === "shuffle") shuffleItems();
-      if (path === "reset") resetToDefaults();
-    },
-  },
-);
+});
 ```
 
 Action buttons trigger callbacks without storing any value. The `label` defaults to the formatted key name (camelCase becomes Title Case). Multiple adjacent actions are grouped vertically.
@@ -390,8 +369,8 @@ DialKit also supports dynamic config updates. If your config shape, defaults, op
 Dynamic configs work with both inline objects and memoized configs — no special consumer action needed:
 
 ```tsx
-const values = useDialKit("Controls", {
-  style: { type: "select", options: dynamicOptions },
+const values = useDialKit('Controls', {
+  style: { type: 'select', options: dynamicOptions },
 });
 ```
 
@@ -402,7 +381,7 @@ const values = useDialKit("Controls", {
 Panels are open by default. Pass `collapsed: true` to start one collapsed:
 
 ```tsx
-const params = useDialKit("Stage", config, { id: "stage", collapsed: true });
+const params = useDialKit('Stage', config, { id: 'stage', collapsed: true });
 ```
 
 The same option exists on `createDialKit` in the Solid, Svelte, and Vue adapters.
@@ -410,20 +389,17 @@ The same option exists on `createDialKit` in the Solid, Svelte, and Vue adapters
 Open state lives in `DialStore`, so you can drive it from anywhere:
 
 ```tsx
-import { DialStore } from "dialkit";
+import { DialStore } from 'dialkit';
 
-DialStore.setPanelOpen("stage", false); // collapse
-DialStore.setPanelOpen("stage", true); // expand
-DialStore.togglePanelOpen("stage");
-DialStore.isPanelOpen("stage"); // boolean
+DialStore.setPanelOpen('stage', false);  // collapse
+DialStore.setPanelOpen('stage', true);   // expand
+DialStore.togglePanelOpen('stage');
+DialStore.isPanelOpen('stage');          // boolean
 ```
 
-These take the panel id — the `id` you passed to `useDialKit`, or the generated
-`${name}-${n}` when you didn't.
+These take the panel id — the `id` you passed to `useDialKit`, or the generated `${name}-${n}` when you didn't.
 
-Open state is in-memory only. It is never persisted, so a reload returns every
-panel to its configured default. To start a _folder_ inside a panel collapsed,
-use the `_collapsed` config key described above.
+Open state is in-memory only. It is never persisted, so a reload returns every panel to its configured default. To start a _folder_ inside a panel collapsed, use the `_collapsed` config key described above.
 
 ---
 
@@ -433,14 +409,14 @@ use the `_collapsed` config key described above.
 <DialRoot position="top-right" />
 ```
 
-| Prop                | Type                                                           | Default                                 |
-| ------------------- | -------------------------------------------------------------- | --------------------------------------- |
-| `position`          | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'`                           |
-| `defaultOpen`       | `boolean`                                                      | `true`                                  |
-| `mode`              | `'popover' \| 'inline'`                                        | `'popover'`                             |
-| `theme`             | `'system' \| 'light' \| 'dark'`                                | `'system'`                              |
-| `productionEnabled` | `boolean`                                                      | `false` in production, `true` otherwise |
-| `onOpenChange`      | `(open: boolean) => void`                                      | `undefined`                             |
+| Prop | Type | Default |
+|------|------|---------|
+| `position` | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'` |
+| `defaultOpen` | `boolean` | `true` |
+| `mode` | `'popover' \| 'inline'` | `'popover'` |
+| `theme` | `'system' \| 'light' \| 'dark'` | `'system'` |
+| `productionEnabled` | `boolean` | `false` in production, `true` otherwise |
+| `onOpenChange` | `(open: boolean) => void` | `undefined` |
 
 Mount once at your app root. In the default `popover` mode, the panel renders via a portal on `document.body`. It collapses to a small icon button and expands to 280px wide on click.
 
@@ -450,24 +426,19 @@ If multiple `useDialKit` calls are registered under the same root, DialKit rende
 
 ```tsx
 function PhotoStack() {
-  const photo = useDialKit("Photo Stack", {
+  const photo = useDialKit('Photo Stack', {
     blur: [12, 0, 40],
     scale: [1, 0.5, 2],
   });
 
-  const stage = useDialKit("Stage", {
+  const stage = useDialKit('Stage', {
     pagePadding: [40, 16, 96],
-    background: "#ffffff",
+    background: '#ffffff',
   });
 
   return (
     <div style={{ padding: stage.pagePadding, background: stage.background }}>
-      <img
-        style={{
-          filter: `blur(${photo.blur}px)`,
-          transform: `scale(${photo.scale})`,
-        }}
-      />
+      <img style={{ filter: `blur(${photo.blur}px)`, transform: `scale(${photo.scale})` }} />
     </div>
   );
 }
@@ -479,9 +450,9 @@ Use `onOpenChange` when you need to persist whether the floating panel is open o
 
 ```tsx
 <DialRoot
-  defaultOpen={localStorage.getItem("dialkit-open") !== "0"}
+  defaultOpen={localStorage.getItem('dialkit-open') !== '0'}
   onOpenChange={(open) => {
-    localStorage.setItem("dialkit-open", open ? "1" : "0");
+    localStorage.setItem('dialkit-open', open ? '1' : '0');
   }}
 />
 ```
@@ -501,23 +472,20 @@ In popover mode, the collapsed panel bubble can be dragged to any position on th
 Use `mode="inline"` to render DialKit directly in your layout instead of as a floating popover. The panel fills its container and scrolls internally, which is useful for embedding in a sidebar or resizable panel. Inline mode works across all frameworks:
 
 **React:**
-
 ```tsx
-<aside style={{ width: 300, height: "100vh", overflow: "hidden" }}>
+<aside style={{ width: 300, height: '100vh', overflow: 'hidden' }}>
   <DialRoot mode="inline" />
 </aside>
 ```
 
 **Solid:**
-
 ```tsx
-<aside style={{ width: "300px", height: "100vh", overflow: "hidden" }}>
+<aside style={{ width: '300px', height: '100vh', overflow: 'hidden' }}>
   <DialRoot mode="inline" />
 </aside>
 ```
 
 **Svelte:**
-
 ```svelte
 <aside style:width="300px" style:height="100vh" style:overflow="hidden">
   <DialRoot mode="inline" />
@@ -542,67 +510,63 @@ When the panel is open, the toolbar provides:
 Assign keyboard shortcuts to controls so you can adjust values without touching the panel. Pass a `shortcuts` map in the options object:
 
 ```tsx
-const p = useDialKit(
-  "Card",
-  {
-    blur: [24, 0, 100],
-    scale: 1.2,
-    opacity: [1, 0, 1],
-    borderRadius: [16, 0, 64],
-    darkMode: true,
-    shadow: {
-      blur: [10, 0, 50],
-    },
+const p = useDialKit('Card', {
+  blur: [24, 0, 100],
+  scale: 1.2,
+  opacity: [1, 0, 1],
+  borderRadius: [16, 0, 64],
+  darkMode: true,
+  shadow: {
+    blur: [10, 0, 50],
   },
-  {
-    shortcuts: {
-      blur: { key: "b", mode: "fine" }, // B+Scroll
-      scale: { key: "s", interaction: "drag", mode: "coarse" }, // S+Drag
-      opacity: { key: "o", interaction: "move" }, // O+Move
-      borderRadius: { interaction: "scroll-only" }, // Scroll (no key)
-      darkMode: { key: "m" }, // press M
-      "shadow.blur": { key: "d", mode: "fine" }, // D+Scroll
-    },
+}, {
+  shortcuts: {
+    blur:          { key: 'b', mode: 'fine' },                          // B+Scroll
+    scale:         { key: 's', interaction: 'drag', mode: 'coarse' },   // S+Drag
+    opacity:       { key: 'o', interaction: 'move' },                   // O+Move
+    borderRadius:  { interaction: 'scroll-only' },                      // Scroll (no key)
+    darkMode:      { key: 'm' },                                        // press M
+    'shadow.blur': { key: 'd', mode: 'fine' },                          // D+Scroll
   },
-);
+});
 ```
 
 ### ShortcutConfig
 
 ```tsx
 type ShortcutConfig = {
-  key?: string; // trigger key (e.g. 'b', 's') — optional for scroll-only
-  modifier?: "alt" | "shift" | "meta"; // optional modifier key
-  mode?: "fine" | "normal" | "coarse"; // precision level (default: 'normal')
-  interaction?: "scroll" | "drag" | "move" | "scroll-only"; // input method (default: 'scroll')
+  key?: string;                                       // trigger key (e.g. 'b', 's') — optional for scroll-only
+  modifier?: 'alt' | 'shift' | 'meta';               // optional modifier key
+  mode?: 'fine' | 'normal' | 'coarse';               // precision level (default: 'normal')
+  interaction?: 'scroll' | 'drag' | 'move' | 'scroll-only'; // input method (default: 'scroll')
 };
 ```
 
 ### Interaction types
 
-| Interaction   | Description                                 | Example pill |
-| ------------- | ------------------------------------------- | ------------ |
-| `scroll`      | Hold key + scroll wheel to adjust (default) | `B+Scroll`   |
-| `drag`        | Hold key + click and drag horizontally      | `S+Drag`     |
-| `move`        | Hold key + move mouse (no click needed)     | `O+Move`     |
-| `scroll-only` | Just scroll anywhere, no key needed         | `Scroll`     |
+| Interaction | Description | Example pill |
+|-------------|-------------|-------------|
+| `scroll` | Hold key + scroll wheel to adjust (default) | `B+Scroll` |
+| `drag` | Hold key + click and drag horizontally | `S+Drag` |
+| `move` | Hold key + move mouse (no click needed) | `O+Move` |
+| `scroll-only` | Just scroll anywhere, no key needed | `Scroll` |
 
 ### Supported controls
 
-| Control    | Interactions                            | Description                           |
-| ---------- | --------------------------------------- | ------------------------------------- |
+| Control | Interactions | Description |
+|---------|-------------|-------------|
 | **Slider** | `scroll`, `drag`, `move`, `scroll-only` | Adjust value with chosen input method |
-| **Toggle** | key press                               | Press the assigned key to flip on/off |
+| **Toggle** | key press | Press the assigned key to flip on/off |
 
 ### Precision modes
 
 For sliders, the `mode` controls how much each scroll tick or drag pixel changes the value:
 
-| Mode     | Step multiplier  | Use case           |
-| -------- | ---------------- | ------------------ |
-| `fine`   | step &divide; 10 | Precision tweaking |
-| `normal` | step &times; 1   | Default behavior   |
-| `coarse` | step &times; 10  | Big sweeps         |
+| Mode | Step multiplier | Use case |
+|------|----------------|----------|
+| `fine` | step &divide; 10 | Precision tweaking |
+| `normal` | step &times; 1 | Default behavior |
+| `coarse` | step &times; 10 | Big sweeps |
 
 ### Nested paths
 
@@ -626,62 +590,50 @@ Shortcuts are automatically disabled when a text input is focused.
 ## Full Example
 
 ```tsx
-import { useDialKit } from "dialkit";
-import { motion } from "motion/react";
+import { useDialKit } from 'dialkit';
+import { motion } from 'motion/react';
 
 function PhotoStack() {
-  const p = useDialKit(
-    "Photo Stack",
-    {
-      // Text inputs
-      title: "Japan",
-      subtitle: {
-        type: "text",
-        default: "December 2025",
-        placeholder: "Enter subtitle...",
-      },
+  const p = useDialKit('Photo Stack', {
+    // Text inputs
+    title: 'Japan',
+    subtitle: { type: 'text', default: 'December 2025', placeholder: 'Enter subtitle...' },
 
-      // Color pickers
-      accentColor: "#c41e3a",
-      shadowTint: { type: "color", default: "#000000" },
+    // Color pickers
+    accentColor: '#c41e3a',
+    shadowTint: { type: 'color', default: '#000000' },
 
-      // Select dropdown
-      layout: {
-        type: "select",
-        options: ["stack", "fan", "grid"],
-        default: "stack",
-      },
+    // Select dropdown
+    layout: { type: 'select', options: ['stack', 'fan', 'grid'], default: 'stack' },
 
-      // Grouped sliders in a folder
-      backPhoto: {
-        offsetX: [239, 0, 400],
-        offsetY: [0, 0, 150],
-        scale: [0.7, 0.5, 0.95],
-        overlayOpacity: [0.6, 0, 1],
-      },
-
-      // Spring config for Motion
-      transitionSpring: { type: "spring", visualDuration: 0.5, bounce: 0.04 },
-
-      // Toggle
-      darkMode: false,
-
-      // Action buttons
-      next: { type: "action" },
-      previous: { type: "action" },
+    // Grouped sliders in a folder
+    backPhoto: {
+      offsetX: [239, 0, 400],
+      offsetY: [0, 0, 150],
+      scale: [0.7, 0.5, 0.95],
+      overlayOpacity: [0.6, 0, 1],
     },
-    {
-      shortcuts: {
-        "backPhoto.offsetX": { key: "x", interaction: "drag", mode: "coarse" },
-        "backPhoto.scale": { key: "s", interaction: "move", mode: "fine" },
-        darkMode: { key: "m" },
-      },
-      onAction: (action) => {
-        if (action === "next") goNext();
-        if (action === "previous") goPrevious();
-      },
+
+    // Spring config for Motion
+    transitionSpring: { type: 'spring', visualDuration: 0.5, bounce: 0.04 },
+
+    // Toggle
+    darkMode: false,
+
+    // Action buttons
+    next: { type: 'action' },
+    previous: { type: 'action' },
+  }, {
+    shortcuts: {
+      'backPhoto.offsetX': { key: 'x', interaction: 'drag', mode: 'coarse' },
+      'backPhoto.scale': { key: 's', interaction: 'move', mode: 'fine' },
+      darkMode: { key: 'm' },
     },
-  );
+    onAction: (action) => {
+      if (action === 'next') goNext();
+      if (action === 'previous') goPrevious();
+    },
+  });
 
   return (
     <motion.div
@@ -707,19 +659,19 @@ The animation's structure stays in code. The timeline editor adjusts its propert
 Timeline is available in React, Solid, Svelte, and Vue. Every adapter uses the same framework-neutral timeline core and store, while lifecycle and rendering stay native to its framework.
 
 ```tsx
-import { useDialTimeline, DialTimeline } from "dialkit";
-import "dialkit/styles.css";
+import { useDialTimeline, DialTimeline } from 'dialkit';
+import 'dialkit/styles.css';
 
 function Hero() {
   const hero = useDialTimeline(
-    "Hero",
+    'Hero',
     {
       entrance: {
         at: 0,
         duration: 0.6,
         from: { y: 32, opacity: 0 },
         to: { y: 0, opacity: 1 },
-        transition: { type: "spring", bounce: 0.2 },
+        transition: { type: 'spring', bounce: 0.2 },
       },
       idle: {
         at: 0.8,
@@ -731,7 +683,7 @@ function Hero() {
         ],
       },
     },
-    { loop: { from: 0.8 } },
+    { loop: { from: 0.8 } }
   );
 
   const entrance = hero.entrance.current;
@@ -739,12 +691,10 @@ function Hero() {
 
   return (
     <>
-      <h1
-        style={{
-          opacity: entrance.opacity,
-          transform: `translateY(${entrance.y + idle.y}px)`,
-        }}
-      >
+      <h1 style={{
+        opacity: entrance.opacity,
+        transform: `translateY(${entrance.y + idle.y}px)`,
+      }}>
         Ship the moment.
       </h1>
       <DialTimeline />
@@ -757,12 +707,12 @@ Each named entry is a clip and appears as one row in the timeline. During author
 
 The framework entry points expose the same config, values, transport, and `<DialTimeline />` dock:
 
-| Framework | Import           | Timeline function    | Read returned values                                                 |
-| --------- | ---------------- | -------------------- | -------------------------------------------------------------------- |
-| React     | `dialkit`        | `useDialTimeline`    | `timeline.card.current`                                              |
-| Solid     | `dialkit/solid`  | `createDialTimeline` | `timeline().card.current`                                            |
-| Svelte 5  | `dialkit/svelte` | `createDialTimeline` | `timeline.card.current`                                              |
-| Vue 3     | `dialkit/vue`    | `useDialTimeline`    | `timeline.value.card.current` in script; auto-unwrapped in templates |
+| Framework | Import | Timeline function | Read returned values |
+|-----------|--------|-------------------|----------------------|
+| React | `dialkit` | `useDialTimeline` | `timeline.card.current` |
+| Solid | `dialkit/solid` | `createDialTimeline` | `timeline().card.current` |
+| Svelte 5 | `dialkit/svelte` | `createDialTimeline` | `timeline.card.current` |
+| Vue 3 | `dialkit/vue` | `useDialTimeline` | `timeline.value.card.current` in script; auto-unwrapped in templates |
 
 ### Timeline function
 
@@ -771,29 +721,29 @@ const tl = useDialTimeline(name, config, options?)
 // Solid/Svelte: createDialTimeline(name, config, options?)
 ```
 
-| Param              | Type                          | Description                                                         |
-| ------------------ | ----------------------------- | ------------------------------------------------------------------- |
-| `name`             | `string`                      | Timeline title displayed in the dock                                |
-| `config`           | `TimelineConfig`              | Clip definitions plus an optional top-level `duration`              |
-| `options.id`       | `string`                      | Stable logical id, same semantics as `useDialKit`                   |
-| `options.persist`  | `DialKitPersistOptions`       | Persist timing edits to browser storage                             |
-| `options.autoplay` | `boolean`                     | Start playing on mount. Default `true`                              |
-| `options.loop`     | `boolean \| { from: number }` | Wrap the playhead when it reaches the end (see [Looping](#looping)) |
+| Param | Type | Description |
+|-------|------|-------------|
+| `name` | `string` | Timeline title displayed in the dock |
+| `config` | `TimelineConfig` | Clip definitions plus an optional top-level `duration` |
+| `options.id` | `string` | Stable logical id, same semantics as `useDialKit` |
+| `options.persist` | `DialKitPersistOptions` | Persist timing edits to browser storage |
+| `options.autoplay` | `boolean` | Start playing on mount. Default `true` |
+| `options.loop` | `boolean \| { from: number }` | Wrap the playhead when it reaches the end (see [Looping](#looping)) |
 
 Clip timing lives in the same store as panel values, so presets, persistence, reset, and Copy all work on timing data with no extra wiring.
 
 The returned object combines the transport with one entry per clip:
 
 ```tsx
-tl.time; // playhead in seconds
-tl.playing; // boolean
-tl.duration; // timeline length in seconds
-tl.play(); // resume (restarts if parked at the end)
-tl.pause();
-tl.replay(); // seek to 0 and play
-tl.seek(1.2); // move the playhead (pins the deterministic first-pass state)
+tl.time        // playhead in seconds
+tl.playing     // boolean
+tl.duration    // timeline length in seconds
+tl.play()      // resume (restarts if parked at the end)
+tl.pause()
+tl.replay()    // seek to 0 and play
+tl.seek(1.2)   // move the playhead (pins the deterministic first-pass state)
 
-tl.headline; // TimelineClipValues for the "headline" clip
+tl.headline    // TimelineClipValues for the "headline" clip
 ```
 
 `time`, `playing`, `duration`, `play`, `pause`, `replay`, and `seek` are reserved — a clip with one of those names is skipped with a console warning.
@@ -821,7 +771,7 @@ card: {
 
 - **`from` / `to`** accept any normal DialKit leaf values — numbers, hex colors — and become editable controls in the clip's popover. Bare numbers get property-aware slider ranges (`x`/`y` ±100, `rotate` ±180, `scale` 0–2, `opacity` 0–1, and so on), expanded to include your actual endpoints.
 - **`transition`** is a spring or easing config, exactly as in the panel's spring editor. Clips with `from`/`to` and no `transition` animate with a default spring (`{ type: 'spring', bounce: 0.2 }`).
-- **The bar owns the duration.** Time-based springs and easings stretch to the bar: resize the clip and the curve retimes. Physics springs (`stiffness`/`damping`/`mass`) work the other way — the duration is _derived_ from their settle time, the bar shows `~0.62s`, and it can't be resized (change the physics instead).
+- **The bar owns the duration.** Time-based springs and easings stretch to the bar: resize the clip and the curve retimes. Physics springs (`stiffness`/`damping`/`mass`) work the other way — the duration is *derived* from their settle time, the bar shows `~0.62s`, and it can't be resized (change the physics instead).
 - **`duration` may be omitted** — it defaults to the easing's duration or the spring's settle time; a `from`/`to` clip with no `transition` gets the default spring's settle time.
 
 Config mistakes warn in the console instead of failing silently: an entry missing `at`, conflicting clip shapes (`steps` + `to`, `props` + `from`), or a sequence property with no starting value.
@@ -839,21 +789,21 @@ shine: { at: 2.7, duration: 0.7 },
 
 Each clip on the returned object is a `TimelineClipValues`:
 
-| Field         | Type                | Description                                                                 |
-| ------------- | ------------------- | --------------------------------------------------------------------------- |
-| `at`          | `number`            | Clip start in seconds — live, reflects dock edits                           |
-| `duration`    | `number`            | Effective duration — the bar length                                         |
-| `loop`        | `'off' \| 'repeat'` | Effective loop mode                                                         |
-| `started`     | `boolean`           | Playhead is at or past the clip start                                       |
-| `active`      | `boolean`           | Playhead is inside the clip (any cycle, for looping clips)                  |
-| `done`        | `boolean`           | Playhead is past the clip end (past the timeline end, for looping clips)    |
-| `progress`    | `number`            | 0–1 position within the clip — a sawtooth per cycle for looping clips       |
-| `step`        | `number`            | Index of the leg under the playhead (sequence clips only)                   |
-| `from` / `to` | `object`            | Resolved endpoint values (`to` is the final merged state for sequences)     |
-| `animate`     | `object`            | `to` once the clip has started, `from` before                               |
-| `transition`  | `TransitionConfig`  | Motion-ready curve, duration driven by the bar (single-curve clips only)    |
-| `css`         | `TimelineClipCss`   | `transitionDuration` + `transitionTimingFunction` (single-curve clips only) |
-| `current`     | `object`            | Values interpolated through the clip's curves at the playhead               |
+| Field | Type | Description |
+|-------|------|-------------|
+| `at` | `number` | Clip start in seconds — live, reflects dock edits |
+| `duration` | `number` | Effective duration — the bar length |
+| `loop` | `'off' \| 'repeat'` | Effective loop mode |
+| `started` | `boolean` | Playhead is at or past the clip start |
+| `active` | `boolean` | Playhead is inside the clip (any cycle, for looping clips) |
+| `done` | `boolean` | Playhead is past the clip end (past the timeline end, for looping clips) |
+| `progress` | `number` | 0–1 position within the clip — a sawtooth per cycle for looping clips |
+| `step` | `number` | Index of the leg under the playhead (sequence clips only) |
+| `from` / `to` | `object` | Resolved endpoint values (`to` is the final merged state for sequences) |
+| `animate` | `object` | `to` once the clip has started, `from` before |
+| `transition` | `TransitionConfig` | Motion-ready curve, duration driven by the bar (single-curve clips only) |
+| `css` | `TimelineClipCss` | `transitionDuration` + `transitionTimingFunction` (single-curve clips only) |
+| `current` | `object` | Values interpolated through the clip's curves at the playhead |
 
 ### Recommended workflow: preview, copy, replace
 
@@ -872,12 +822,10 @@ There are three ways to bind a clip while authoring:
 **1. `current` — recommended for tuning.** Bind styles directly; the element sits at DialKit's sampled state at all times, giving you true scrubbing. DialKit remains the renderer until you replace this binding with your production animation.
 
 ```tsx
-<div
-  style={{
-    opacity: tl.card.current.opacity,
-    transform: `translateY(${tl.card.current.y}px) scale(${tl.card.current.scale})`,
-  }}
-/>
+<div style={{
+  opacity: tl.card.current.opacity,
+  transform: `translateY(${tl.card.current.y}px) scale(${tl.card.current.scale})`,
+}} />
 ```
 
 **2. `animate` + `transition` — real Motion during authoring.** The clip start flips `animate` from `from` to `to`, so Motion runs the actual curve. The tradeoff is that timeline scrubbing snaps between endpoints instead of showing intermediate states.
@@ -889,14 +837,12 @@ There are three ways to bind a clip while authoring:
 **3. `animate` + `css` — native CSS during authoring.** Same endpoint flip, using a CSS transition. Easing curves map exactly; springs are approximated with an overshoot bezier, and scrubbing still snaps between endpoints.
 
 ```tsx
-<div
-  style={{
-    opacity: tl.card.animate.opacity,
-    transform: `translateY(${tl.card.animate.y}px)`,
-    transitionProperty: "transform, opacity",
-    ...tl.card.css,
-  }}
-/>
+<div style={{
+  opacity: tl.card.animate.opacity,
+  transform: `translateY(${tl.card.animate.y}px)`,
+  transitionProperty: 'transform, opacity',
+  ...tl.card.css,
+}} />
 ```
 
 ### Sequences — `steps`
@@ -925,7 +871,7 @@ path: {
 
 ### Property tracks — `props`
 
-When one element's properties need _independent_ timing — different durations, different curves, offset phases — give each property a full track:
+When one element's properties need *independent* timing — different durations, different curves, offset phases — give each property a full track:
 
 ```tsx
 float: {
@@ -962,15 +908,15 @@ Each track is a mini-clip: its own `from`/`to` or `steps`, `duration`, `transiti
 Nesting clips one level under a key groups them into a collapsible layer in the dock. Purely presentational — values nest the same way:
 
 ```tsx
-const tl = useDialTimeline("Compound", {
+const tl = useDialTimeline('Compound', {
   circle: {
-    path: { at: 0 /* ... */ },
-    float: { at: 0 /* ... */ },
+    path:  { at: 0, /* ... */ },
+    float: { at: 0, /* ... */ },
   },
 });
 
-tl.circle.path.current;
-tl.circle.float.current;
+tl.circle.path.current
+tl.circle.float.current
 ```
 
 ### Looping
@@ -979,11 +925,11 @@ There are two loop controls, and they compose:
 
 **Clip loop** — `loop: true` on a clip repeats its cycle from `at` until the timeline ends. The bar is one cycle, so dragging it longer slows the loop. Looping is code-defined rather than editable in the dock. There is no mirror mode — a loop that should return home (a bob, a pulse) is a sequence whose last leg lands back on the starting values, which also puts the loop seam at a natural zero-velocity point.
 
-**Timeline loop** — the `loop` option wraps the _playhead_:
+**Timeline loop** — the `loop` option wraps the *playhead*:
 
 ```tsx
-useDialTimeline("Hero", config, { loop: true }); // wrap to 0
-useDialTimeline("Hero", config, { loop: { from: 1.4 } }); // wrap to 1.4s
+useDialTimeline('Hero', config, { loop: true });           // wrap to 0
+useDialTimeline('Hero', config, { loop: { from: 1.4 } });  // wrap to 1.4s
 ```
 
 `{ from }` is the intro-then-idle pattern: clips before that time play exactly once, and looping clips inside the region keep cycling with continuous phase — no snap at the wrap. Scrubbing always pins the deterministic first-pass state.
@@ -991,9 +937,9 @@ useDialTimeline("Hero", config, { loop: { from: 1.4 } }); // wrap to 1.4s
 **Event-driven timelines** — pass `autoplay: false` and drive the transport from your app. The dock and your code share the same clock: click your real button, watch the playhead run, scrub back, tune, click again.
 
 ```tsx
-const toast = useDialTimeline("Toast", config, { autoplay: false });
+const toast = useDialTimeline('Toast', config, { autoplay: false });
 
-<button onClick={() => toast.replay()}>Save changes</button>;
+<button onClick={() => toast.replay()}>Save changes</button>
 ```
 
 ### Timeline duration
@@ -1001,9 +947,9 @@ const toast = useDialTimeline("Toast", config, { autoplay: false });
 The top-level `duration` is the minimum editing window. Omit it and DialKit initially infers an exact fit to the last clip's end. If a live edit—such as switching to a longer physics spring—would move content past that boundary, DialKit extends the timeline automatically. Set `duration` explicitly when you want deliberate slack; authored content is never clipped to fit it.
 
 ```tsx
-const tl = useDialTimeline("Hero", {
-  duration: 4, // seconds; minimum window, inferred when omitted
-  headline: { at: 0.45 /* ... */ },
+const tl = useDialTimeline('Hero', {
+  duration: 4,          // seconds; minimum window, inferred when omitted
+  headline: { at: 0.45, /* ... */ },
 });
 ```
 
@@ -1015,14 +961,14 @@ Mount once, anywhere. The dock renders fixed to the bottom of the screen via a p
 <DialTimeline theme="dark" />
 ```
 
-| Prop                 | Type                            | Default                                 |
-| -------------------- | ------------------------------- | --------------------------------------- |
-| `theme`              | `'system' \| 'light' \| 'dark'` | `'system'`                              |
-| `defaultVisible`     | `boolean`                       | `true`                                  |
-| `visible`            | `boolean`                       | uncontrolled                            |
-| `onVisibilityChange` | `(visible: boolean) => void`    | `undefined`                             |
-| `defaultOpen`        | `boolean`                       | `true`                                  |
-| `productionEnabled`  | `boolean`                       | `false` in production, `true` otherwise |
+| Prop | Type | Default |
+|------|------|---------|
+| `theme` | `'system' \| 'light' \| 'dark'` | `'system'` |
+| `defaultVisible` | `boolean` | `true` |
+| `visible` | `boolean` | uncontrolled |
+| `onVisibilityChange` | `(visible: boolean) => void` | `undefined` |
+| `defaultOpen` | `boolean` | `true` |
+| `productionEnabled` | `boolean` | `false` in production, `true` otherwise |
 
 Each section's toolbar has **Play/Pause**, **Add Version**, a version selector, **Copy**, and a collapse chevron. The collapsed toolbar stays playable and keeps its full-range overview scrubber, so you can inspect the animation without opening the detailed tracks.
 
@@ -1058,8 +1004,8 @@ npm install dialkit solid-js
 
 ```tsx
 // App.tsx
-import { DialRoot } from "dialkit/solid";
-import "dialkit/styles.css";
+import { DialRoot } from 'dialkit/solid';
+import 'dialkit/styles.css';
 
 export default function App() {
   return (
@@ -1073,25 +1019,23 @@ export default function App() {
 
 ```tsx
 // component.tsx
-import { createDialKit } from "dialkit/solid";
+import { createDialKit } from 'dialkit/solid';
 
 function Card() {
-  const params = createDialKit("Card", {
+  const params = createDialKit('Card', {
     blur: [24, 0, 100],
     scale: 1.2,
-    color: "#ff5500",
+    color: '#ff5500',
     visible: true,
   });
 
   return (
-    <div
-      style={{
-        filter: `blur(${params().blur}px)`,
-        transform: `scale(${params().scale})`,
-        color: params().color,
-        opacity: params().visible ? 1 : 0,
-      }}
-    >
+    <div style={{
+      filter: `blur(${params().blur}px)`,
+      transform: `scale(${params().scale})`,
+      color: params().color,
+      opacity: params().visible ? 1 : 0,
+    }}>
       ...
     </div>
   );
@@ -1103,10 +1047,10 @@ function Card() {
 Solid timelines use the same accessor shape:
 
 ```tsx
-import { createDialTimeline, DialTimeline } from "dialkit/solid";
+import { createDialTimeline, DialTimeline } from 'dialkit/solid';
 
 function Hero() {
-  const timeline = createDialTimeline("Hero", {
+  const timeline = createDialTimeline('Hero', {
     entrance: {
       at: 0,
       duration: 0.6,
@@ -1115,21 +1059,19 @@ function Hero() {
     },
   });
 
-  return (
-    <>
-      <h1 style={{ opacity: timeline().entrance.current.opacity }}>Ship it.</h1>
-      <DialTimeline />
-    </>
-  );
+  return <>
+    <h1 style={{ opacity: timeline().entrance.current.opacity }}>Ship it.</h1>
+    <DialTimeline />
+  </>;
 }
 ```
 
 Use `createDialKitController` when Solid code needs to update values:
 
 ```tsx
-import { createDialKitController } from "dialkit/solid";
+import { createDialKitController } from 'dialkit/solid';
 
-const dial = createDialKitController("Card", {
+const dial = createDialKitController('Card', {
   blur: [24, 0, 100],
   shadow: { radius: [16, 0, 64] },
 });
@@ -1235,54 +1177,48 @@ npm install dialkit motion-v vue
 
 ```ts
 // main.ts
-import { createApp } from "vue";
-import { DialRoot } from "dialkit/vue";
-import "dialkit/styles.css";
-import App from "./App.vue";
+import { createApp } from 'vue';
+import { DialRoot } from 'dialkit/vue';
+import 'dialkit/styles.css';
+import App from './App.vue';
 
 const app = createApp(App);
-app.mount("#app");
+app.mount('#app');
 ```
 
 ```vue
 <!-- App.vue -->
 <script setup>
-import { DialRoot } from "dialkit/vue";
-import Card from "./Card.vue";
+import { DialRoot } from 'dialkit/vue';
+import Card from './Card.vue';
 </script>
 
 <template>
   <Card />
-  <DialRoot
-    @open-change="
-      (open) => localStorage.setItem('dialkit-open', open ? '1' : '0')
-    "
-  />
+  <DialRoot @open-change="(open) => localStorage.setItem('dialkit-open', open ? '1' : '0')" />
 </template>
 ```
 
 ```vue
 <!-- Card.vue -->
 <script setup>
-import { useDialKit } from "dialkit/vue";
+import { useDialKit } from 'dialkit/vue';
 
-const params = useDialKit("Card", {
+const params = useDialKit('Card', {
   blur: [24, 0, 100],
   scale: 1.2,
-  color: "#ff5500",
+  color: '#ff5500',
   visible: true,
 });
 </script>
 
 <template>
-  <div
-    :style="{
-      filter: `blur(${params.blur}px)`,
-      transform: `scale(${params.scale})`,
-      color: params.color,
-      opacity: params.visible ? 1 : 0,
-    }"
-  >
+  <div :style="{
+    filter: `blur(${params.blur}px)`,
+    transform: `scale(${params.scale})`,
+    color: params.color,
+    opacity: params.visible ? 1 : 0,
+  }">
     ...
   </div>
 </template>
@@ -1294,9 +1230,9 @@ Vue timelines return a computed ref, which templates unwrap automatically:
 
 ```vue
 <script setup>
-import { useDialTimeline, DialTimeline } from "dialkit/vue";
+import { useDialTimeline, DialTimeline } from 'dialkit/vue';
 
-const timeline = useDialTimeline("Hero", {
+const timeline = useDialTimeline('Hero', {
   entrance: {
     at: 0,
     duration: 0.6,
@@ -1316,25 +1252,18 @@ Use `useDialKitController` when Vue code needs to update values:
 
 ```vue
 <script setup>
-import { useDialKitController } from "dialkit/vue";
+import { useDialKitController } from 'dialkit/vue';
 
-const { values, setValues, resetValues } = useDialKitController("Card", {
+const { values, setValues, resetValues } = useDialKitController('Card', {
   blur: [24, 0, 100],
   shadow: { radius: [16, 0, 64] },
 });
 </script>
 
 <template>
-  <button @click="setValues({ blur: 48, shadow: { radius: 28 } })">
-    Apply preset
-  </button>
+  <button @click="setValues({ blur: 48, shadow: { radius: 28 } })">Apply preset</button>
   <button @click="resetValues()">Reset</button>
-  <div
-    :style="{
-      filter: `blur(${values.blur}px)`,
-      borderRadius: `${values.shadow.radius}px`,
-    }"
-  />
+  <div :style="{ filter: `blur(${values.blur}px)`, borderRadius: `${values.shadow.radius}px` }" />
 </template>
 ```
 
@@ -1363,7 +1292,7 @@ import type {
   ControlMeta,
   PanelConfig,
   Preset,
-} from "dialkit";
+} from 'dialkit';
 ```
 
 Timeline types are exported as well:
@@ -1384,7 +1313,7 @@ import type {
   DialTimelineValues,
   UseDialTimelineOptions,
   DialTimelineProps,
-} from "dialkit";
+} from 'dialkit';
 ```
 
 Return values are fully typed: `params.blur` infers as `number`, `params.color` as `string`, `params.spring` as `SpringConfig`, `params.shadow` as a nested object, etc. Timeline values are typed from the config shape too — `tl.card.current.y` infers as `number`, and `step` only exists on sequence clips.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ const params = useDialKit(name, config, options?)
 | `config` | `DialConfig` | Parameter definitions (see Control Types below) |
 | `options.id` | `string` | Stable logical id for sharing values across remounts/pages |
 | `options.persist` | `DialKitPersistOptions` | Persist values to browser storage |
+| `options.collapsed` | `boolean` | Start this panel collapsed (see [Panel open state](#panel-open-state)) |
 | `options.onAction` | `(path: string) => void` | Callback when action buttons are clicked |
 | `options.shortcuts` | `Record<string, ShortcutConfig>` | Keyboard shortcuts for controls (see [Keyboard Shortcuts](#keyboard-shortcuts)) |
 
@@ -372,6 +373,36 @@ const values = useDialKit('Controls', {
   style: { type: 'select', options: dynamicOptions },
 });
 ```
+
+---
+
+## Panel open state
+
+Panels are open by default. Pass `collapsed: true` to start one collapsed:
+
+```tsx
+const params = useDialKit('Stage', config, { id: 'stage', collapsed: true });
+```
+
+The same option exists on `createDialKit` in the Solid, Svelte, and Vue adapters.
+
+Open state lives in `DialStore`, so you can drive it from anywhere:
+
+```tsx
+import { DialStore } from 'dialkit';
+
+DialStore.setPanelOpen('stage', false);   // collapse
+DialStore.setPanelOpen('stage', true);    // expand
+DialStore.togglePanelOpen('stage');
+DialStore.isPanelOpen('stage');           // boolean
+```
+
+These take the panel id — the `id` you passed to `useDialKit`, or the generated
+`${name}-${n}` when you didn't.
+
+Open state is in-memory only. It is never persisted, so a reload returns every
+panel to its configured default. To start a *folder* inside a panel collapsed,
+use the `_collapsed` config key described above.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ npm install dialkit motion
 
 ```tsx
 // layout.tsx
-import { DialRoot } from 'dialkit';
-import 'dialkit/styles.css';
+import { DialRoot } from "dialkit";
+import "dialkit/styles.css";
 
 export default function Layout({ children }) {
   return (
@@ -37,23 +37,25 @@ export default function Layout({ children }) {
 
 ```tsx
 // component.tsx
-import { useDialKit } from 'dialkit';
+import { useDialKit } from "dialkit";
 
 function Card() {
-  const p = useDialKit('Card', {
+  const p = useDialKit("Card", {
     blur: [24, 0, 100],
     scale: 1.2,
-    color: '#ff5500',
+    color: "#ff5500",
     visible: true,
   });
 
   return (
-    <div style={{
-      filter: `blur(${p.blur}px)`,
-      transform: `scale(${p.scale})`,
-      color: p.color,
-      opacity: p.visible ? 1 : 0,
-    }}>
+    <div
+      style={{
+        filter: `blur(${p.blur}px)`,
+        transform: `scale(${p.scale})`,
+        color: p.color,
+        opacity: p.visible ? 1 : 0,
+      }}
+    >
       ...
     </div>
   );
@@ -68,15 +70,15 @@ function Card() {
 const params = useDialKit(name, config, options?)
 ```
 
-| Param | Type | Description |
-|-------|------|-------------|
-| `name` | `string` | Panel title displayed in the UI |
-| `config` | `DialConfig` | Parameter definitions (see Control Types below) |
-| `options.id` | `string` | Stable logical id for sharing values across remounts/pages |
-| `options.persist` | `DialKitPersistOptions` | Persist values to browser storage |
-| `options.onAction` | `(path: string) => void` | Callback when action buttons are clicked |
-| `options.shortcuts` | `Record<string, ShortcutConfig>` | Keyboard shortcuts for controls (see [Keyboard Shortcuts](#keyboard-shortcuts)) |
-| `options.collapsed` | `boolean` | Start this panel collapsed (see [Panel open state](#panel-open-state)) |
+| Param                      | Type                             | Description                                                                     |
+| -------------------------- | -------------------------------- | ------------------------------------------------------------------------------- |
+| `name`                     | `string`                         | Panel title displayed in the UI                                                 |
+| `config`                   | `DialConfig`                     | Parameter definitions (see Control Types below)                                 |
+| `options.id`               | `string`                         | Stable logical id for sharing values across remounts/pages                      |
+| `options.persist`          | `DialKitPersistOptions`          | Persist values to browser storage                                               |
+| `options.onAction`         | `(path: string) => void`         | Callback when action buttons are clicked                                        |
+| `options.shortcuts`        | `Record<string, ShortcutConfig>` | Keyboard shortcuts for controls (see [Keyboard Shortcuts](#keyboard-shortcuts)) |
+| `options.defaultCollapsed` | `boolean`                        | Start this panel collapsed (see [Panel open state](#panel-open-state))          |
 
 Returns a fully typed object matching your config shape with live values. Updating a control in the UI immediately updates the returned values.
 
@@ -88,17 +90,21 @@ By default, a DialKit panel is tied to the lifecycle of the component that calls
 
 ```tsx
 // dials/useOnboardingDials.ts
-import { useDialKit } from 'dialkit';
+import { useDialKit } from "dialkit";
 
 export function useOnboardingDials() {
-  return useDialKit('Onboarding', {
-    name: { type: 'text', default: 'Avery', placeholder: 'Name' },
-    avatarScale: [1, 0.6, 1.6, 0.01],
-    accent: { type: 'color', default: '#6C5CE7' },
-  }, {
-    id: 'onboarding',
-    persist: true,
-  });
+  return useDialKit(
+    "Onboarding",
+    {
+      name: { type: "text", default: "Avery", placeholder: "Name" },
+      avatarScale: [1, 0.6, 1.6, 0.01],
+      accent: { type: "color", default: "#6C5CE7" },
+    },
+    {
+      id: "onboarding",
+      persist: true,
+    },
+  );
 }
 ```
 
@@ -108,7 +114,7 @@ Use that helper anywhere the shared values are needed:
 function PageTwo() {
   const onboarding = useOnboardingDials();
 
-  const page = useDialKit('Page Two', {
+  const page = useDialKit("Page Two", {
     cardRadius: [16, 0, 64],
   });
 
@@ -127,11 +133,11 @@ When `PageTwo` is mounted, the single `<DialRoot />` shows both `Onboarding` and
 `persist: true` stores values, presets, and the active preset in `localStorage` using `dialkit:${id}` as the key. Use the object form to customize storage:
 
 ```tsx
-useDialKit('Onboarding', config, {
-  id: 'onboarding',
+useDialKit("Onboarding", config, {
+  id: "onboarding",
   persist: {
-    key: 'my-app:onboarding-dials',
-    storage: 'sessionStorage',
+    key: "my-app:onboarding-dials",
+    storage: "sessionStorage",
     presets: false,
   },
 });
@@ -146,13 +152,13 @@ The `id` string has no special format; it only needs to be reused wherever you w
 Use the controller API when your app code also needs to update DialKit values, such as reset buttons, URL sync, or app-defined preset buttons.
 
 ```tsx
-import { useDialKitController } from 'dialkit';
+import { useDialKitController } from "dialkit";
 
 function Card() {
-  const dial = useDialKitController('Card', {
+  const dial = useDialKitController("Card", {
     blur: [24, 0, 100],
     scale: 1.2,
-    color: '#ff5500',
+    color: "#ff5500",
     visible: true,
     shadow: {
       radius: [16, 0, 64],
@@ -161,22 +167,28 @@ function Card() {
 
   return (
     <>
-      <button onClick={() => dial.setValues({
-        blur: 48,
-        scale: 1,
-        shadow: { radius: 28 },
-      })}>
+      <button
+        onClick={() =>
+          dial.setValues({
+            blur: 48,
+            scale: 1,
+            shadow: { radius: 28 },
+          })
+        }
+      >
         Apply preset
       </button>
       <button onClick={() => dial.resetValues()}>Reset</button>
 
-      <div style={{
-        filter: `blur(${dial.values.blur}px)`,
-        transform: `scale(${dial.values.scale})`,
-        color: dial.values.color,
-        opacity: dial.values.visible ? 1 : 0,
-        borderRadius: dial.values.shadow.radius,
-      }}>
+      <div
+        style={{
+          filter: `blur(${dial.values.blur}px)`,
+          transform: `scale(${dial.values.scale})`,
+          color: dial.values.color,
+          opacity: dial.values.visible ? 1 : 0,
+          borderRadius: dial.values.shadow.radius,
+        }}
+      >
         ...
       </div>
     </>
@@ -186,13 +198,13 @@ function Card() {
 
 Controller methods:
 
-| Method | Description |
-|--------|-------------|
-| `values` | The same live resolved values returned by `useDialKit` |
-| `setValue(path, value)` | Updates one control by dot path, like `'shadow.radius'` |
-| `setValues(values)` | Updates multiple controls with a typed nested partial object |
-| `resetValues()` | Restores the current config defaults and clears the active preset |
-| `getValues()` | Reads the latest resolved values outside render callbacks |
+| Method                  | Description                                                       |
+| ----------------------- | ----------------------------------------------------------------- |
+| `values`                | The same live resolved values returned by `useDialKit`            |
+| `setValue(path, value)` | Updates one control by dot path, like `'shadow.radius'`           |
+| `setValues(values)`     | Updates multiple controls with a typed nested partial object      |
+| `resetValues()`         | Restores the current config defaults and clears the active preset |
+| `getValues()`           | Reads the latest resolved values outside render callbacks         |
 
 Programmatic updates use the same state as panel edits. If a saved preset is active, updates are saved into that preset; otherwise they update the base "Version 1" values. Action controls are triggers, so they are not set by `setValues`.
 
@@ -205,28 +217,33 @@ Programmatic updates use the same state as panel edits. If a saved preset is act
 Numbers create sliders. There are three ways to define them:
 
 **Explicit range** — `[default, min, max]`:
+
 ```tsx
-blur: [24, 0, 100]
+blur: [24, 0, 100];
 ```
 
 **Explicit range + step** — `[default, min, max, step]`:
+
 ```tsx
-blur: [24, 0, 100, 5]    // snaps in increments of 5
+blur: [24, 0, 100, 5]; // snaps in increments of 5
 ```
+
 When `step` is omitted, it's inferred from the range (see table below).
 
 **Auto-inferred** — bare number:
+
 ```tsx
-scale: 1.2
+scale: 1.2;
 ```
+
 A single number auto-infers a reasonable min, max, and step:
 
-| Value range | Inferred min/max | Step |
-|-------------|-----------------|------|
-| 0–1 | 0 to 1 | 0.01 |
-| 0–10 | 0 to value &times; 3 | 0.1 |
-| 0–100 | 0 to value &times; 3 | 1 |
-| 100+ | 0 to value &times; 3 | 10 |
+| Value range | Inferred min/max     | Step |
+| ----------- | -------------------- | ---- |
+| 0–1         | 0 to 1               | 0.01 |
+| 0–10        | 0 to value &times; 3 | 0.1  |
+| 0–100       | 0 to value &times; 3 | 1    |
+| 100+        | 0 to value &times; 3 | 10   |
 
 **Returns:** `number`
 
@@ -235,8 +252,8 @@ Sliders support click-to-snap (with spring animation), drag with rubber-band ove
 ### Toggle
 
 ```tsx
-enabled: true
-darkMode: false
+enabled: true;
+darkMode: false;
 ```
 
 Booleans create an Off/On segmented control.
@@ -311,12 +328,12 @@ Creates a visual spring editor with a live animation curve preview. The editor s
 The returned config object is passed directly to Motion's `transition` prop:
 
 ```tsx
-const p = useDialKit('Card', {
-  spring: { type: 'spring', visualDuration: 0.5, bounce: 0.04 },
+const p = useDialKit("Card", {
+  spring: { type: "spring", visualDuration: 0.5, bounce: 0.04 },
   x: [0, -200, 200],
 });
 
-<motion.div animate={{ x: p.x }} transition={p.spring} />
+<motion.div animate={{ x: p.x }} transition={p.spring} />;
 ```
 
 **Returns:** `SpringConfig` (pass directly to Motion)
@@ -324,15 +341,19 @@ const p = useDialKit('Card', {
 ### Action
 
 ```tsx
-const p = useDialKit('Controls', {
-  shuffle: { type: 'action' },
-  reset: { type: 'action', label: 'Reset All' },
-}, {
-  onAction: (path) => {
-    if (path === 'shuffle') shuffleItems();
-    if (path === 'reset') resetToDefaults();
+const p = useDialKit(
+  "Controls",
+  {
+    shuffle: { type: "action" },
+    reset: { type: "action", label: "Reset All" },
   },
-});
+  {
+    onAction: (path) => {
+      if (path === "shuffle") shuffleItems();
+      if (path === "reset") resetToDefaults();
+    },
+  },
+);
 ```
 
 Action buttons trigger callbacks without storing any value. The `label` defaults to the formatted key name (camelCase becomes Title Case). Multiple adjacent actions are grouped vertically.
@@ -369,8 +390,8 @@ DialKit also supports dynamic config updates. If your config shape, defaults, op
 Dynamic configs work with both inline objects and memoized configs — no special consumer action needed:
 
 ```tsx
-const values = useDialKit('Controls', {
-  style: { type: 'select', options: dynamicOptions },
+const values = useDialKit("Controls", {
+  style: { type: "select", options: dynamicOptions },
 });
 ```
 
@@ -378,10 +399,10 @@ const values = useDialKit('Controls', {
 
 ## Panel open state
 
-Panels are open by default. Pass `collapsed: true` to start one collapsed:
+Panels are open by default. Pass `defaultCollapsed: true` to start one collapsed:
 
 ```tsx
-const params = useDialKit('Stage', config, { id: 'stage', collapsed: true });
+const params = useDialKit("Stage", config, { id: "stage", defaultCollapsed: true });
 ```
 
 The same option exists on `createDialKit` in the Solid, Svelte, and Vue adapters.
@@ -389,12 +410,12 @@ The same option exists on `createDialKit` in the Solid, Svelte, and Vue adapters
 Open state lives in `DialStore`, so you can drive it from anywhere:
 
 ```tsx
-import { DialStore } from 'dialkit';
+import { DialStore } from "dialkit";
 
-DialStore.setPanelOpen('stage', false);  // collapse
-DialStore.setPanelOpen('stage', true);   // expand
-DialStore.togglePanelOpen('stage');
-DialStore.isPanelOpen('stage');          // boolean
+DialStore.setPanelOpen("stage", false); // collapse
+DialStore.setPanelOpen("stage", true); // expand
+DialStore.togglePanelOpen("stage");
+DialStore.isPanelOpen("stage"); // boolean
 ```
 
 These take the panel id — the `id` you passed to `useDialKit`, or the generated `${name}-${n}` when you didn't.
@@ -409,14 +430,14 @@ Open state is in-memory only. It is never persisted, so a reload returns every p
 <DialRoot position="top-right" />
 ```
 
-| Prop | Type | Default |
-|------|------|---------|
-| `position` | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'` |
-| `defaultOpen` | `boolean` | `true` |
-| `mode` | `'popover' \| 'inline'` | `'popover'` |
-| `theme` | `'system' \| 'light' \| 'dark'` | `'system'` |
-| `productionEnabled` | `boolean` | `false` in production, `true` otherwise |
-| `onOpenChange` | `(open: boolean) => void` | `undefined` |
+| Prop                | Type                                                           | Default                                 |
+| ------------------- | -------------------------------------------------------------- | --------------------------------------- |
+| `position`          | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'`                           |
+| `defaultOpen`       | `boolean`                                                      | `true`                                  |
+| `mode`              | `'popover' \| 'inline'`                                        | `'popover'`                             |
+| `theme`             | `'system' \| 'light' \| 'dark'`                                | `'system'`                              |
+| `productionEnabled` | `boolean`                                                      | `false` in production, `true` otherwise |
+| `onOpenChange`      | `(open: boolean) => void`                                      | `undefined`                             |
 
 Mount once at your app root. In the default `popover` mode, the panel renders via a portal on `document.body`. It collapses to a small icon button and expands to 280px wide on click.
 
@@ -426,19 +447,24 @@ If multiple `useDialKit` calls are registered under the same root, DialKit rende
 
 ```tsx
 function PhotoStack() {
-  const photo = useDialKit('Photo Stack', {
+  const photo = useDialKit("Photo Stack", {
     blur: [12, 0, 40],
     scale: [1, 0.5, 2],
   });
 
-  const stage = useDialKit('Stage', {
+  const stage = useDialKit("Stage", {
     pagePadding: [40, 16, 96],
-    background: '#ffffff',
+    background: "#ffffff",
   });
 
   return (
     <div style={{ padding: stage.pagePadding, background: stage.background }}>
-      <img style={{ filter: `blur(${photo.blur}px)`, transform: `scale(${photo.scale})` }} />
+      <img
+        style={{
+          filter: `blur(${photo.blur}px)`,
+          transform: `scale(${photo.scale})`,
+        }}
+      />
     </div>
   );
 }
@@ -450,9 +476,9 @@ Use `onOpenChange` when you need to persist whether the floating panel is open o
 
 ```tsx
 <DialRoot
-  defaultOpen={localStorage.getItem('dialkit-open') !== '0'}
+  defaultOpen={localStorage.getItem("dialkit-open") !== "0"}
   onOpenChange={(open) => {
-    localStorage.setItem('dialkit-open', open ? '1' : '0');
+    localStorage.setItem("dialkit-open", open ? "1" : "0");
   }}
 />
 ```
@@ -472,20 +498,23 @@ In popover mode, the collapsed panel bubble can be dragged to any position on th
 Use `mode="inline"` to render DialKit directly in your layout instead of as a floating popover. The panel fills its container and scrolls internally, which is useful for embedding in a sidebar or resizable panel. Inline mode works across all frameworks:
 
 **React:**
+
 ```tsx
-<aside style={{ width: 300, height: '100vh', overflow: 'hidden' }}>
+<aside style={{ width: 300, height: "100vh", overflow: "hidden" }}>
   <DialRoot mode="inline" />
 </aside>
 ```
 
 **Solid:**
+
 ```tsx
-<aside style={{ width: '300px', height: '100vh', overflow: 'hidden' }}>
+<aside style={{ width: "300px", height: "100vh", overflow: "hidden" }}>
   <DialRoot mode="inline" />
 </aside>
 ```
 
 **Svelte:**
+
 ```svelte
 <aside style:width="300px" style:height="100vh" style:overflow="hidden">
   <DialRoot mode="inline" />
@@ -510,63 +539,67 @@ When the panel is open, the toolbar provides:
 Assign keyboard shortcuts to controls so you can adjust values without touching the panel. Pass a `shortcuts` map in the options object:
 
 ```tsx
-const p = useDialKit('Card', {
-  blur: [24, 0, 100],
-  scale: 1.2,
-  opacity: [1, 0, 1],
-  borderRadius: [16, 0, 64],
-  darkMode: true,
-  shadow: {
-    blur: [10, 0, 50],
+const p = useDialKit(
+  "Card",
+  {
+    blur: [24, 0, 100],
+    scale: 1.2,
+    opacity: [1, 0, 1],
+    borderRadius: [16, 0, 64],
+    darkMode: true,
+    shadow: {
+      blur: [10, 0, 50],
+    },
   },
-}, {
-  shortcuts: {
-    blur:          { key: 'b', mode: 'fine' },                          // B+Scroll
-    scale:         { key: 's', interaction: 'drag', mode: 'coarse' },   // S+Drag
-    opacity:       { key: 'o', interaction: 'move' },                   // O+Move
-    borderRadius:  { interaction: 'scroll-only' },                      // Scroll (no key)
-    darkMode:      { key: 'm' },                                        // press M
-    'shadow.blur': { key: 'd', mode: 'fine' },                          // D+Scroll
+  {
+    shortcuts: {
+      blur: { key: "b", mode: "fine" }, // B+Scroll
+      scale: { key: "s", interaction: "drag", mode: "coarse" }, // S+Drag
+      opacity: { key: "o", interaction: "move" }, // O+Move
+      borderRadius: { interaction: "scroll-only" }, // Scroll (no key)
+      darkMode: { key: "m" }, // press M
+      "shadow.blur": { key: "d", mode: "fine" }, // D+Scroll
+    },
   },
-});
+);
 ```
 
 ### ShortcutConfig
 
 ```tsx
 type ShortcutConfig = {
-  key?: string;                                       // trigger key (e.g. 'b', 's') — optional for scroll-only
-  modifier?: 'alt' | 'shift' | 'meta';               // optional modifier key
-  mode?: 'fine' | 'normal' | 'coarse';               // precision level (default: 'normal')
-  interaction?: 'scroll' | 'drag' | 'move' | 'scroll-only'; // input method (default: 'scroll')
+  key?: string; // trigger key (e.g. 'b', 's') — optional for scroll-only
+  modifier?: "alt" | "shift" | "meta"; // optional modifier key
+  mode?: "fine" | "normal" | "coarse"; // precision level (default: 'normal')
+  interaction?: "scroll" | "drag" | "move" | "scroll-only"; // input method (default: 'scroll')
 };
 ```
 
 ### Interaction types
 
-| Interaction | Description | Example pill |
-|-------------|-------------|-------------|
-| `scroll` | Hold key + scroll wheel to adjust (default) | `B+Scroll` |
-| `drag` | Hold key + click and drag horizontally | `S+Drag` |
-| `move` | Hold key + move mouse (no click needed) | `O+Move` |
-| `scroll-only` | Just scroll anywhere, no key needed | `Scroll` |
+| Interaction   | Description                                 | Example pill |
+| ------------- | ------------------------------------------- | ------------ |
+| `scroll`      | Hold key + scroll wheel to adjust (default) | `B+Scroll`   |
+| `drag`        | Hold key + click and drag horizontally      | `S+Drag`     |
+| `move`        | Hold key + move mouse (no click needed)     | `O+Move`     |
+| `scroll-only` | Just scroll anywhere, no key needed         | `Scroll`     |
 
 ### Supported controls
 
-| Control | Interactions | Description |
-|---------|-------------|-------------|
+| Control    | Interactions                            | Description                           |
+| ---------- | --------------------------------------- | ------------------------------------- |
 | **Slider** | `scroll`, `drag`, `move`, `scroll-only` | Adjust value with chosen input method |
-| **Toggle** | key press | Press the assigned key to flip on/off |
+| **Toggle** | key press                               | Press the assigned key to flip on/off |
 
 ### Precision modes
 
 For sliders, the `mode` controls how much each scroll tick or drag pixel changes the value:
 
-| Mode | Step multiplier | Use case |
-|------|----------------|----------|
-| `fine` | step &divide; 10 | Precision tweaking |
-| `normal` | step &times; 1 | Default behavior |
-| `coarse` | step &times; 10 | Big sweeps |
+| Mode     | Step multiplier  | Use case           |
+| -------- | ---------------- | ------------------ |
+| `fine`   | step &divide; 10 | Precision tweaking |
+| `normal` | step &times; 1   | Default behavior   |
+| `coarse` | step &times; 10  | Big sweeps         |
 
 ### Nested paths
 
@@ -590,50 +623,62 @@ Shortcuts are automatically disabled when a text input is focused.
 ## Full Example
 
 ```tsx
-import { useDialKit } from 'dialkit';
-import { motion } from 'motion/react';
+import { useDialKit } from "dialkit";
+import { motion } from "motion/react";
 
 function PhotoStack() {
-  const p = useDialKit('Photo Stack', {
-    // Text inputs
-    title: 'Japan',
-    subtitle: { type: 'text', default: 'December 2025', placeholder: 'Enter subtitle...' },
+  const p = useDialKit(
+    "Photo Stack",
+    {
+      // Text inputs
+      title: "Japan",
+      subtitle: {
+        type: "text",
+        default: "December 2025",
+        placeholder: "Enter subtitle...",
+      },
 
-    // Color pickers
-    accentColor: '#c41e3a',
-    shadowTint: { type: 'color', default: '#000000' },
+      // Color pickers
+      accentColor: "#c41e3a",
+      shadowTint: { type: "color", default: "#000000" },
 
-    // Select dropdown
-    layout: { type: 'select', options: ['stack', 'fan', 'grid'], default: 'stack' },
+      // Select dropdown
+      layout: {
+        type: "select",
+        options: ["stack", "fan", "grid"],
+        default: "stack",
+      },
 
-    // Grouped sliders in a folder
-    backPhoto: {
-      offsetX: [239, 0, 400],
-      offsetY: [0, 0, 150],
-      scale: [0.7, 0.5, 0.95],
-      overlayOpacity: [0.6, 0, 1],
+      // Grouped sliders in a folder
+      backPhoto: {
+        offsetX: [239, 0, 400],
+        offsetY: [0, 0, 150],
+        scale: [0.7, 0.5, 0.95],
+        overlayOpacity: [0.6, 0, 1],
+      },
+
+      // Spring config for Motion
+      transitionSpring: { type: "spring", visualDuration: 0.5, bounce: 0.04 },
+
+      // Toggle
+      darkMode: false,
+
+      // Action buttons
+      next: { type: "action" },
+      previous: { type: "action" },
     },
-
-    // Spring config for Motion
-    transitionSpring: { type: 'spring', visualDuration: 0.5, bounce: 0.04 },
-
-    // Toggle
-    darkMode: false,
-
-    // Action buttons
-    next: { type: 'action' },
-    previous: { type: 'action' },
-  }, {
-    shortcuts: {
-      'backPhoto.offsetX': { key: 'x', interaction: 'drag', mode: 'coarse' },
-      'backPhoto.scale': { key: 's', interaction: 'move', mode: 'fine' },
-      darkMode: { key: 'm' },
+    {
+      shortcuts: {
+        "backPhoto.offsetX": { key: "x", interaction: "drag", mode: "coarse" },
+        "backPhoto.scale": { key: "s", interaction: "move", mode: "fine" },
+        darkMode: { key: "m" },
+      },
+      onAction: (action) => {
+        if (action === "next") goNext();
+        if (action === "previous") goPrevious();
+      },
     },
-    onAction: (action) => {
-      if (action === 'next') goNext();
-      if (action === 'previous') goPrevious();
-    },
-  });
+  );
 
   return (
     <motion.div
@@ -659,19 +704,19 @@ The animation's structure stays in code. The timeline editor adjusts its propert
 Timeline is available in React, Solid, Svelte, and Vue. Every adapter uses the same framework-neutral timeline core and store, while lifecycle and rendering stay native to its framework.
 
 ```tsx
-import { useDialTimeline, DialTimeline } from 'dialkit';
-import 'dialkit/styles.css';
+import { useDialTimeline, DialTimeline } from "dialkit";
+import "dialkit/styles.css";
 
 function Hero() {
   const hero = useDialTimeline(
-    'Hero',
+    "Hero",
     {
       entrance: {
         at: 0,
         duration: 0.6,
         from: { y: 32, opacity: 0 },
         to: { y: 0, opacity: 1 },
-        transition: { type: 'spring', bounce: 0.2 },
+        transition: { type: "spring", bounce: 0.2 },
       },
       idle: {
         at: 0.8,
@@ -683,7 +728,7 @@ function Hero() {
         ],
       },
     },
-    { loop: { from: 0.8 } }
+    { loop: { from: 0.8 } },
   );
 
   const entrance = hero.entrance.current;
@@ -691,10 +736,12 @@ function Hero() {
 
   return (
     <>
-      <h1 style={{
-        opacity: entrance.opacity,
-        transform: `translateY(${entrance.y + idle.y}px)`,
-      }}>
+      <h1
+        style={{
+          opacity: entrance.opacity,
+          transform: `translateY(${entrance.y + idle.y}px)`,
+        }}
+      >
         Ship the moment.
       </h1>
       <DialTimeline />
@@ -707,12 +754,12 @@ Each named entry is a clip and appears as one row in the timeline. During author
 
 The framework entry points expose the same config, values, transport, and `<DialTimeline />` dock:
 
-| Framework | Import | Timeline function | Read returned values |
-|-----------|--------|-------------------|----------------------|
-| React | `dialkit` | `useDialTimeline` | `timeline.card.current` |
-| Solid | `dialkit/solid` | `createDialTimeline` | `timeline().card.current` |
-| Svelte 5 | `dialkit/svelte` | `createDialTimeline` | `timeline.card.current` |
-| Vue 3 | `dialkit/vue` | `useDialTimeline` | `timeline.value.card.current` in script; auto-unwrapped in templates |
+| Framework | Import           | Timeline function    | Read returned values                                                 |
+| --------- | ---------------- | -------------------- | -------------------------------------------------------------------- |
+| React     | `dialkit`        | `useDialTimeline`    | `timeline.card.current`                                              |
+| Solid     | `dialkit/solid`  | `createDialTimeline` | `timeline().card.current`                                            |
+| Svelte 5  | `dialkit/svelte` | `createDialTimeline` | `timeline.card.current`                                              |
+| Vue 3     | `dialkit/vue`    | `useDialTimeline`    | `timeline.value.card.current` in script; auto-unwrapped in templates |
 
 ### Timeline function
 
@@ -721,29 +768,29 @@ const tl = useDialTimeline(name, config, options?)
 // Solid/Svelte: createDialTimeline(name, config, options?)
 ```
 
-| Param | Type | Description |
-|-------|------|-------------|
-| `name` | `string` | Timeline title displayed in the dock |
-| `config` | `TimelineConfig` | Clip definitions plus an optional top-level `duration` |
-| `options.id` | `string` | Stable logical id, same semantics as `useDialKit` |
-| `options.persist` | `DialKitPersistOptions` | Persist timing edits to browser storage |
-| `options.autoplay` | `boolean` | Start playing on mount. Default `true` |
-| `options.loop` | `boolean \| { from: number }` | Wrap the playhead when it reaches the end (see [Looping](#looping)) |
+| Param              | Type                          | Description                                                         |
+| ------------------ | ----------------------------- | ------------------------------------------------------------------- |
+| `name`             | `string`                      | Timeline title displayed in the dock                                |
+| `config`           | `TimelineConfig`              | Clip definitions plus an optional top-level `duration`              |
+| `options.id`       | `string`                      | Stable logical id, same semantics as `useDialKit`                   |
+| `options.persist`  | `DialKitPersistOptions`       | Persist timing edits to browser storage                             |
+| `options.autoplay` | `boolean`                     | Start playing on mount. Default `true`                              |
+| `options.loop`     | `boolean \| { from: number }` | Wrap the playhead when it reaches the end (see [Looping](#looping)) |
 
 Clip timing lives in the same store as panel values, so presets, persistence, reset, and Copy all work on timing data with no extra wiring.
 
 The returned object combines the transport with one entry per clip:
 
 ```tsx
-tl.time        // playhead in seconds
-tl.playing     // boolean
-tl.duration    // timeline length in seconds
-tl.play()      // resume (restarts if parked at the end)
-tl.pause()
-tl.replay()    // seek to 0 and play
-tl.seek(1.2)   // move the playhead (pins the deterministic first-pass state)
+tl.time; // playhead in seconds
+tl.playing; // boolean
+tl.duration; // timeline length in seconds
+tl.play(); // resume (restarts if parked at the end)
+tl.pause();
+tl.replay(); // seek to 0 and play
+tl.seek(1.2); // move the playhead (pins the deterministic first-pass state)
 
-tl.headline    // TimelineClipValues for the "headline" clip
+tl.headline; // TimelineClipValues for the "headline" clip
 ```
 
 `time`, `playing`, `duration`, `play`, `pause`, `replay`, and `seek` are reserved — a clip with one of those names is skipped with a console warning.
@@ -771,7 +818,7 @@ card: {
 
 - **`from` / `to`** accept any normal DialKit leaf values — numbers, hex colors — and become editable controls in the clip's popover. Bare numbers get property-aware slider ranges (`x`/`y` ±100, `rotate` ±180, `scale` 0–2, `opacity` 0–1, and so on), expanded to include your actual endpoints.
 - **`transition`** is a spring or easing config, exactly as in the panel's spring editor. Clips with `from`/`to` and no `transition` animate with a default spring (`{ type: 'spring', bounce: 0.2 }`).
-- **The bar owns the duration.** Time-based springs and easings stretch to the bar: resize the clip and the curve retimes. Physics springs (`stiffness`/`damping`/`mass`) work the other way — the duration is *derived* from their settle time, the bar shows `~0.62s`, and it can't be resized (change the physics instead).
+- **The bar owns the duration.** Time-based springs and easings stretch to the bar: resize the clip and the curve retimes. Physics springs (`stiffness`/`damping`/`mass`) work the other way — the duration is _derived_ from their settle time, the bar shows `~0.62s`, and it can't be resized (change the physics instead).
 - **`duration` may be omitted** — it defaults to the easing's duration or the spring's settle time; a `from`/`to` clip with no `transition` gets the default spring's settle time.
 
 Config mistakes warn in the console instead of failing silently: an entry missing `at`, conflicting clip shapes (`steps` + `to`, `props` + `from`), or a sequence property with no starting value.
@@ -789,21 +836,21 @@ shine: { at: 2.7, duration: 0.7 },
 
 Each clip on the returned object is a `TimelineClipValues`:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `at` | `number` | Clip start in seconds — live, reflects dock edits |
-| `duration` | `number` | Effective duration — the bar length |
-| `loop` | `'off' \| 'repeat'` | Effective loop mode |
-| `started` | `boolean` | Playhead is at or past the clip start |
-| `active` | `boolean` | Playhead is inside the clip (any cycle, for looping clips) |
-| `done` | `boolean` | Playhead is past the clip end (past the timeline end, for looping clips) |
-| `progress` | `number` | 0–1 position within the clip — a sawtooth per cycle for looping clips |
-| `step` | `number` | Index of the leg under the playhead (sequence clips only) |
-| `from` / `to` | `object` | Resolved endpoint values (`to` is the final merged state for sequences) |
-| `animate` | `object` | `to` once the clip has started, `from` before |
-| `transition` | `TransitionConfig` | Motion-ready curve, duration driven by the bar (single-curve clips only) |
-| `css` | `TimelineClipCss` | `transitionDuration` + `transitionTimingFunction` (single-curve clips only) |
-| `current` | `object` | Values interpolated through the clip's curves at the playhead |
+| Field         | Type                | Description                                                                 |
+| ------------- | ------------------- | --------------------------------------------------------------------------- |
+| `at`          | `number`            | Clip start in seconds — live, reflects dock edits                           |
+| `duration`    | `number`            | Effective duration — the bar length                                         |
+| `loop`        | `'off' \| 'repeat'` | Effective loop mode                                                         |
+| `started`     | `boolean`           | Playhead is at or past the clip start                                       |
+| `active`      | `boolean`           | Playhead is inside the clip (any cycle, for looping clips)                  |
+| `done`        | `boolean`           | Playhead is past the clip end (past the timeline end, for looping clips)    |
+| `progress`    | `number`            | 0–1 position within the clip — a sawtooth per cycle for looping clips       |
+| `step`        | `number`            | Index of the leg under the playhead (sequence clips only)                   |
+| `from` / `to` | `object`            | Resolved endpoint values (`to` is the final merged state for sequences)     |
+| `animate`     | `object`            | `to` once the clip has started, `from` before                               |
+| `transition`  | `TransitionConfig`  | Motion-ready curve, duration driven by the bar (single-curve clips only)    |
+| `css`         | `TimelineClipCss`   | `transitionDuration` + `transitionTimingFunction` (single-curve clips only) |
+| `current`     | `object`            | Values interpolated through the clip's curves at the playhead               |
 
 ### Recommended workflow: preview, copy, replace
 
@@ -822,10 +869,12 @@ There are three ways to bind a clip while authoring:
 **1. `current` — recommended for tuning.** Bind styles directly; the element sits at DialKit's sampled state at all times, giving you true scrubbing. DialKit remains the renderer until you replace this binding with your production animation.
 
 ```tsx
-<div style={{
-  opacity: tl.card.current.opacity,
-  transform: `translateY(${tl.card.current.y}px) scale(${tl.card.current.scale})`,
-}} />
+<div
+  style={{
+    opacity: tl.card.current.opacity,
+    transform: `translateY(${tl.card.current.y}px) scale(${tl.card.current.scale})`,
+  }}
+/>
 ```
 
 **2. `animate` + `transition` — real Motion during authoring.** The clip start flips `animate` from `from` to `to`, so Motion runs the actual curve. The tradeoff is that timeline scrubbing snaps between endpoints instead of showing intermediate states.
@@ -837,12 +886,14 @@ There are three ways to bind a clip while authoring:
 **3. `animate` + `css` — native CSS during authoring.** Same endpoint flip, using a CSS transition. Easing curves map exactly; springs are approximated with an overshoot bezier, and scrubbing still snaps between endpoints.
 
 ```tsx
-<div style={{
-  opacity: tl.card.animate.opacity,
-  transform: `translateY(${tl.card.animate.y}px)`,
-  transitionProperty: 'transform, opacity',
-  ...tl.card.css,
-}} />
+<div
+  style={{
+    opacity: tl.card.animate.opacity,
+    transform: `translateY(${tl.card.animate.y}px)`,
+    transitionProperty: "transform, opacity",
+    ...tl.card.css,
+  }}
+/>
 ```
 
 ### Sequences — `steps`
@@ -871,7 +922,7 @@ path: {
 
 ### Property tracks — `props`
 
-When one element's properties need *independent* timing — different durations, different curves, offset phases — give each property a full track:
+When one element's properties need _independent_ timing — different durations, different curves, offset phases — give each property a full track:
 
 ```tsx
 float: {
@@ -908,15 +959,15 @@ Each track is a mini-clip: its own `from`/`to` or `steps`, `duration`, `transiti
 Nesting clips one level under a key groups them into a collapsible layer in the dock. Purely presentational — values nest the same way:
 
 ```tsx
-const tl = useDialTimeline('Compound', {
+const tl = useDialTimeline("Compound", {
   circle: {
-    path:  { at: 0, /* ... */ },
-    float: { at: 0, /* ... */ },
+    path: { at: 0 /* ... */ },
+    float: { at: 0 /* ... */ },
   },
 });
 
-tl.circle.path.current
-tl.circle.float.current
+tl.circle.path.current;
+tl.circle.float.current;
 ```
 
 ### Looping
@@ -925,11 +976,11 @@ There are two loop controls, and they compose:
 
 **Clip loop** — `loop: true` on a clip repeats its cycle from `at` until the timeline ends. The bar is one cycle, so dragging it longer slows the loop. Looping is code-defined rather than editable in the dock. There is no mirror mode — a loop that should return home (a bob, a pulse) is a sequence whose last leg lands back on the starting values, which also puts the loop seam at a natural zero-velocity point.
 
-**Timeline loop** — the `loop` option wraps the *playhead*:
+**Timeline loop** — the `loop` option wraps the _playhead_:
 
 ```tsx
-useDialTimeline('Hero', config, { loop: true });           // wrap to 0
-useDialTimeline('Hero', config, { loop: { from: 1.4 } });  // wrap to 1.4s
+useDialTimeline("Hero", config, { loop: true }); // wrap to 0
+useDialTimeline("Hero", config, { loop: { from: 1.4 } }); // wrap to 1.4s
 ```
 
 `{ from }` is the intro-then-idle pattern: clips before that time play exactly once, and looping clips inside the region keep cycling with continuous phase — no snap at the wrap. Scrubbing always pins the deterministic first-pass state.
@@ -937,9 +988,9 @@ useDialTimeline('Hero', config, { loop: { from: 1.4 } });  // wrap to 1.4s
 **Event-driven timelines** — pass `autoplay: false` and drive the transport from your app. The dock and your code share the same clock: click your real button, watch the playhead run, scrub back, tune, click again.
 
 ```tsx
-const toast = useDialTimeline('Toast', config, { autoplay: false });
+const toast = useDialTimeline("Toast", config, { autoplay: false });
 
-<button onClick={() => toast.replay()}>Save changes</button>
+<button onClick={() => toast.replay()}>Save changes</button>;
 ```
 
 ### Timeline duration
@@ -947,9 +998,9 @@ const toast = useDialTimeline('Toast', config, { autoplay: false });
 The top-level `duration` is the minimum editing window. Omit it and DialKit initially infers an exact fit to the last clip's end. If a live edit—such as switching to a longer physics spring—would move content past that boundary, DialKit extends the timeline automatically. Set `duration` explicitly when you want deliberate slack; authored content is never clipped to fit it.
 
 ```tsx
-const tl = useDialTimeline('Hero', {
-  duration: 4,          // seconds; minimum window, inferred when omitted
-  headline: { at: 0.45, /* ... */ },
+const tl = useDialTimeline("Hero", {
+  duration: 4, // seconds; minimum window, inferred when omitted
+  headline: { at: 0.45 /* ... */ },
 });
 ```
 
@@ -961,14 +1012,14 @@ Mount once, anywhere. The dock renders fixed to the bottom of the screen via a p
 <DialTimeline theme="dark" />
 ```
 
-| Prop | Type | Default |
-|------|------|---------|
-| `theme` | `'system' \| 'light' \| 'dark'` | `'system'` |
-| `defaultVisible` | `boolean` | `true` |
-| `visible` | `boolean` | uncontrolled |
-| `onVisibilityChange` | `(visible: boolean) => void` | `undefined` |
-| `defaultOpen` | `boolean` | `true` |
-| `productionEnabled` | `boolean` | `false` in production, `true` otherwise |
+| Prop                 | Type                            | Default                                 |
+| -------------------- | ------------------------------- | --------------------------------------- |
+| `theme`              | `'system' \| 'light' \| 'dark'` | `'system'`                              |
+| `defaultVisible`     | `boolean`                       | `true`                                  |
+| `visible`            | `boolean`                       | uncontrolled                            |
+| `onVisibilityChange` | `(visible: boolean) => void`    | `undefined`                             |
+| `defaultOpen`        | `boolean`                       | `true`                                  |
+| `productionEnabled`  | `boolean`                       | `false` in production, `true` otherwise |
 
 Each section's toolbar has **Play/Pause**, **Add Version**, a version selector, **Copy**, and a collapse chevron. The collapsed toolbar stays playable and keeps its full-range overview scrubber, so you can inspect the animation without opening the detailed tracks.
 
@@ -1004,8 +1055,8 @@ npm install dialkit solid-js
 
 ```tsx
 // App.tsx
-import { DialRoot } from 'dialkit/solid';
-import 'dialkit/styles.css';
+import { DialRoot } from "dialkit/solid";
+import "dialkit/styles.css";
 
 export default function App() {
   return (
@@ -1019,23 +1070,25 @@ export default function App() {
 
 ```tsx
 // component.tsx
-import { createDialKit } from 'dialkit/solid';
+import { createDialKit } from "dialkit/solid";
 
 function Card() {
-  const params = createDialKit('Card', {
+  const params = createDialKit("Card", {
     blur: [24, 0, 100],
     scale: 1.2,
-    color: '#ff5500',
+    color: "#ff5500",
     visible: true,
   });
 
   return (
-    <div style={{
-      filter: `blur(${params().blur}px)`,
-      transform: `scale(${params().scale})`,
-      color: params().color,
-      opacity: params().visible ? 1 : 0,
-    }}>
+    <div
+      style={{
+        filter: `blur(${params().blur}px)`,
+        transform: `scale(${params().scale})`,
+        color: params().color,
+        opacity: params().visible ? 1 : 0,
+      }}
+    >
       ...
     </div>
   );
@@ -1047,10 +1100,10 @@ function Card() {
 Solid timelines use the same accessor shape:
 
 ```tsx
-import { createDialTimeline, DialTimeline } from 'dialkit/solid';
+import { createDialTimeline, DialTimeline } from "dialkit/solid";
 
 function Hero() {
-  const timeline = createDialTimeline('Hero', {
+  const timeline = createDialTimeline("Hero", {
     entrance: {
       at: 0,
       duration: 0.6,
@@ -1059,19 +1112,21 @@ function Hero() {
     },
   });
 
-  return <>
-    <h1 style={{ opacity: timeline().entrance.current.opacity }}>Ship it.</h1>
-    <DialTimeline />
-  </>;
+  return (
+    <>
+      <h1 style={{ opacity: timeline().entrance.current.opacity }}>Ship it.</h1>
+      <DialTimeline />
+    </>
+  );
 }
 ```
 
 Use `createDialKitController` when Solid code needs to update values:
 
 ```tsx
-import { createDialKitController } from 'dialkit/solid';
+import { createDialKitController } from "dialkit/solid";
 
-const dial = createDialKitController('Card', {
+const dial = createDialKitController("Card", {
   blur: [24, 0, 100],
   shadow: { radius: [16, 0, 64] },
 });
@@ -1177,48 +1232,54 @@ npm install dialkit motion-v vue
 
 ```ts
 // main.ts
-import { createApp } from 'vue';
-import { DialRoot } from 'dialkit/vue';
-import 'dialkit/styles.css';
-import App from './App.vue';
+import { createApp } from "vue";
+import { DialRoot } from "dialkit/vue";
+import "dialkit/styles.css";
+import App from "./App.vue";
 
 const app = createApp(App);
-app.mount('#app');
+app.mount("#app");
 ```
 
 ```vue
 <!-- App.vue -->
 <script setup>
-import { DialRoot } from 'dialkit/vue';
-import Card from './Card.vue';
+import { DialRoot } from "dialkit/vue";
+import Card from "./Card.vue";
 </script>
 
 <template>
   <Card />
-  <DialRoot @open-change="(open) => localStorage.setItem('dialkit-open', open ? '1' : '0')" />
+  <DialRoot
+    @open-change="
+      (open) => localStorage.setItem('dialkit-open', open ? '1' : '0')
+    "
+  />
 </template>
 ```
 
 ```vue
 <!-- Card.vue -->
 <script setup>
-import { useDialKit } from 'dialkit/vue';
+import { useDialKit } from "dialkit/vue";
 
-const params = useDialKit('Card', {
+const params = useDialKit("Card", {
   blur: [24, 0, 100],
   scale: 1.2,
-  color: '#ff5500',
+  color: "#ff5500",
   visible: true,
 });
 </script>
 
 <template>
-  <div :style="{
-    filter: `blur(${params.blur}px)`,
-    transform: `scale(${params.scale})`,
-    color: params.color,
-    opacity: params.visible ? 1 : 0,
-  }">
+  <div
+    :style="{
+      filter: `blur(${params.blur}px)`,
+      transform: `scale(${params.scale})`,
+      color: params.color,
+      opacity: params.visible ? 1 : 0,
+    }"
+  >
     ...
   </div>
 </template>
@@ -1230,9 +1291,9 @@ Vue timelines return a computed ref, which templates unwrap automatically:
 
 ```vue
 <script setup>
-import { useDialTimeline, DialTimeline } from 'dialkit/vue';
+import { useDialTimeline, DialTimeline } from "dialkit/vue";
 
-const timeline = useDialTimeline('Hero', {
+const timeline = useDialTimeline("Hero", {
   entrance: {
     at: 0,
     duration: 0.6,
@@ -1252,18 +1313,25 @@ Use `useDialKitController` when Vue code needs to update values:
 
 ```vue
 <script setup>
-import { useDialKitController } from 'dialkit/vue';
+import { useDialKitController } from "dialkit/vue";
 
-const { values, setValues, resetValues } = useDialKitController('Card', {
+const { values, setValues, resetValues } = useDialKitController("Card", {
   blur: [24, 0, 100],
   shadow: { radius: [16, 0, 64] },
 });
 </script>
 
 <template>
-  <button @click="setValues({ blur: 48, shadow: { radius: 28 } })">Apply preset</button>
+  <button @click="setValues({ blur: 48, shadow: { radius: 28 } })">
+    Apply preset
+  </button>
   <button @click="resetValues()">Reset</button>
-  <div :style="{ filter: `blur(${values.blur}px)`, borderRadius: `${values.shadow.radius}px` }" />
+  <div
+    :style="{
+      filter: `blur(${values.blur}px)`,
+      borderRadius: `${values.shadow.radius}px`,
+    }"
+  />
 </template>
 ```
 
@@ -1292,7 +1360,7 @@ import type {
   ControlMeta,
   PanelConfig,
   Preset,
-} from 'dialkit';
+} from "dialkit";
 ```
 
 Timeline types are exported as well:
@@ -1313,7 +1381,7 @@ import type {
   DialTimelineValues,
   UseDialTimelineOptions,
   DialTimelineProps,
-} from 'dialkit';
+} from "dialkit";
 ```
 
 Return values are fully typed: `params.blur` infers as `number`, `params.color` as `string`, `params.spring` as `SpringConfig`, `params.shadow` as a nested object, etc. Timeline values are typed from the config shape too — `tl.card.current.y` infers as `number`, and `step` only exists on sequence clips.

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1,18 +1,26 @@
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { DialRoot } from 'dialkit';
-import 'dialkit/styles.css';
-import { PhotoStack } from './PhotoStack';
-import { Release } from './Release';
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { DialRoot } from "dialkit";
+import "dialkit/styles.css";
+import { PhotoStack } from "./PhotoStack";
+import { Release } from "./Release";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<><PhotoStack /><DialRoot position="top-right" /></>} />
+        <Route
+          path="/"
+          element={
+            <>
+              <PhotoStack />
+              <DialRoot position="top-right" />
+            </>
+          }
+        />
         <Route path="/release-1.2" element={<Release />} />
       </Routes>
     </BrowserRouter>
-  </StrictMode>
+  </StrictMode>,
 );

--- a/example/src/main.tsx
+++ b/example/src/main.tsx
@@ -1,26 +1,18 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { DialRoot } from "dialkit";
-import "dialkit/styles.css";
-import { PhotoStack } from "./PhotoStack";
-import { Release } from "./Release";
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { DialRoot } from 'dialkit';
+import 'dialkit/styles.css';
+import { PhotoStack } from './PhotoStack';
+import { Release } from './Release';
 
-createRoot(document.getElementById("root")!).render(
+createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
-        <Route
-          path="/"
-          element={
-            <>
-              <PhotoStack />
-              <DialRoot position="top-right" />
-            </>
-          }
-        />
+        <Route path="/" element={<><PhotoStack /><DialRoot position="top-right" /></>} />
         <Route path="/release-1.2" element={<Release />} />
       </Routes>
     </BrowserRouter>
-  </StrictMode>,
+  </StrictMode>
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dialkit",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dialkit",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MIT",
       "devDependencies": {
         "@sveltejs/package": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dialkit",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "Real-time parameter tweaking for React, Solid, Svelte, and Vue apps",
   "type": "module",
   "sideEffects": false,

--- a/src/components/DialRoot.tsx
+++ b/src/components/DialRoot.tsx
@@ -38,7 +38,6 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
   const dragStartRef = useRef<{ pointerX: number; pointerY: number; elX: number; elY: number } | null>(null);
   const didDragRef = useRef(false);
   const dragTargetRef = useRef<HTMLElement | null>(null);
-  const panelOpenStatesRef = useRef<Map<string, boolean>>(new Map());
   const rootOpenRef = useRef<boolean | null>(null);
 
   // Subscribe to registered editing surfaces. Timeline-backed panels render
@@ -63,12 +62,7 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
 
   useEffect(() => {
     const fallbackOpen = inline || defaultOpen;
-    const nextStates = new Map<string, boolean>();
-    for (const panel of panels) {
-      nextStates.set(panel.id, panelOpenStatesRef.current.get(panel.id) ?? fallbackOpen);
-    }
-    panelOpenStatesRef.current = nextStates;
-    rootOpenRef.current = Array.from(nextStates.values()).some(Boolean);
+    rootOpenRef.current = panels.some((panel) => DialStore.getPanelOpen(panel.id) ?? fallbackOpen);
   }, [defaultOpen, inline, panels]);
 
   // Watch for panel open/close — snap to corner on open, restore drag position on close
@@ -145,23 +139,17 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
     dragTargetRef.current = null;
   }, []);
 
-  const handlePanelOpenChange = useCallback((panelId: string, open: boolean) => {
-    panelOpenStatesRef.current.set(panelId, open);
-    const fallbackOpen = inline || defaultOpen;
-    const nextRootOpen = panels.some((panel) => (
-      panelOpenStatesRef.current.get(panel.id) ?? fallbackOpen
-    ));
-
-    if (rootOpenRef.current === nextRootOpen) return;
-    rootOpenRef.current = nextRootOpen;
-    onOpenChange?.(nextRootOpen);
-  }, [defaultOpen, inline, onOpenChange, panels]);
-
   const handleRootOpenChange = useCallback((open: boolean) => {
     if (rootOpenRef.current === open) return;
     rootOpenRef.current = open;
     onOpenChange?.(open);
   }, [onOpenChange]);
+
+  // Sections write their own state to the store, so re-derive from it.
+  const handleSectionOpenChange = useCallback(() => {
+    const fallbackOpen = inline || defaultOpen;
+    handleRootOpenChange(panels.some((panel) => DialStore.getPanelOpen(panel.id) ?? fallbackOpen));
+  }, [defaultOpen, handleRootOpenChange, inline, panels]);
 
   // Don't render on server
   if (!mounted || typeof window === 'undefined') {
@@ -230,6 +218,7 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
                   panel={panel}
                   defaultOpen={true}
                   variant="section"
+                  onOpenChange={handleSectionOpenChange}
                 />
               ))}
             </Folder>
@@ -242,7 +231,7 @@ export function DialRoot({ position = 'top-right', defaultOpen = true, mode = 'p
               defaultOpen={inline || defaultOpen}
               inline={inline}
               toolbarExtra={timelineToggle}
-              onOpenChange={(open) => handlePanelOpenChange(panel.id, open)}
+              onOpenChange={handleRootOpenChange}
             />
           ))
         )}

--- a/src/components/Folder.tsx
+++ b/src/components/Folder.tsx
@@ -6,6 +6,7 @@ interface FolderProps {
   title: string;
   children: ReactNode;
   defaultOpen?: boolean;
+  open?: boolean;
   isRoot?: boolean;
   inline?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
@@ -13,9 +14,9 @@ interface FolderProps {
   panelHeightOffset?: number;
 }
 
-export function Folder({ title, children, defaultOpen = true, isRoot = false, inline = false, onOpenChange, toolbar, panelHeightOffset = 10 }: FolderProps) {
-  const [isOpen, setIsOpen] = useState(defaultOpen);
-  const [isCollapsed, setIsCollapsed] = useState(!defaultOpen);
+export function Folder({ title, children, defaultOpen = true, open, isRoot = false, inline = false, onOpenChange, toolbar, panelHeightOffset = 10 }: FolderProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
+  const isOpen = open ?? uncontrolledOpen;
   const contentRef = useRef<HTMLDivElement>(null);
   const [contentHeight, setContentHeight] = useState<number | undefined>(undefined);
   const [windowHeight, setWindowHeight] = useState(typeof window !== 'undefined' ? window.innerHeight : 800);
@@ -44,12 +45,7 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, in
   const handleToggle = () => {
     if (inline && isRoot) return;
     const next = !isOpen;
-    setIsOpen(next);
-    if (next) {
-      setIsCollapsed(false);
-    } else {
-      setIsCollapsed(true);
-    }
+    if (open === undefined) setUncontrolledOpen(next);
     onOpenChange?.(next);
   };
 
@@ -148,7 +144,7 @@ export function Folder({ title, children, defaultOpen = true, isRoot = false, in
         className="dialkit-panel-inner"
         style={panelStyle}
         onClick={!isOpen ? handleToggle : undefined}
-        data-collapsed={isCollapsed}
+        data-collapsed={!isOpen}
         whileTap={!isOpen ? { scale: 0.9 } : undefined}
         transition={{ type: 'spring', visualDuration: 0.15, bounce: 0.3 }}
       >

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
 import type { ReactNode } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import { DialStore, PanelConfig } from '../store/DialStore';
@@ -20,7 +20,6 @@ interface PanelProps {
 
 export function Panel({ panel, defaultOpen = true, inline = false, onOpenChange, variant = 'root', toolbarExtra }: PanelProps) {
   const [copied, setCopied] = useState(false);
-  const [isPanelOpen, setIsPanelOpen] = useState(defaultOpen);
   const hasShortcuts = Object.keys(panel.shortcuts).length > 0;
   const subscribe = useCallback(
     (callback: () => void) => DialStore.subscribe(panel.id, callback),
@@ -30,9 +29,21 @@ export function Panel({ panel, defaultOpen = true, inline = false, onOpenChange,
     () => DialStore.getValues(panel.id),
     [panel.id]
   );
+  const getOpenSnapshot = useCallback(
+    () => DialStore.getPanelOpen(panel.id),
+    [panel.id]
+  );
 
   // Subscribe to panel value changes
   const values = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  // The store owns open/collapsed state so it can be driven programmatically.
+  const storeOpen = useSyncExternalStore(subscribe, getOpenSnapshot, getOpenSnapshot);
+  const isOpen = storeOpen ?? defaultOpen;
+
+  useEffect(() => {
+    DialStore.initPanelOpen(panel.id, defaultOpen);
+  }, [panel.id, defaultOpen]);
 
   const presets = DialStore.getPresets(panel.id);
   const activePresetId = DialStore.getActivePresetId(panel.id);
@@ -49,9 +60,9 @@ export function Panel({ panel, defaultOpen = true, inline = false, onOpenChange,
   };
 
   const handleOpenChange = useCallback((open: boolean) => {
-    setIsPanelOpen(open);
+    DialStore.setPanelOpen(panel.id, open);
     onOpenChange?.(open);
-  }, [onOpenChange]);
+  }, [onOpenChange, panel.id]);
 
   const renderControls = () => (
     <ControlRenderer panelId={panel.id} controls={panel.controls} values={values} />
@@ -134,7 +145,7 @@ export function Panel({ panel, defaultOpen = true, inline = false, onOpenChange,
 
   if (variant === 'section') {
     return (
-      <Folder title={panel.name} defaultOpen={defaultOpen} onOpenChange={handleOpenChange}>
+      <Folder title={panel.name} open={isOpen} onOpenChange={handleOpenChange}>
         <div className="dialkit-panel-section-toolbar" onClick={(e) => e.stopPropagation()}>
           {toolbar}
         </div>
@@ -145,7 +156,7 @@ export function Panel({ panel, defaultOpen = true, inline = false, onOpenChange,
 
   return (
     <div className="dialkit-panel-wrapper">
-      <Folder title={panel.name} defaultOpen={defaultOpen} isRoot={true} inline={inline} onOpenChange={handleOpenChange} toolbar={toolbar}>
+      <Folder title={panel.name} open={isOpen} isRoot={true} inline={inline} onOpenChange={handleOpenChange} toolbar={toolbar}>
         {renderControls()}
       </Folder>
     </div>

--- a/src/dial-store-panel-open.test.ts
+++ b/src/dial-store-panel-open.test.ts
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { DialStore } from './store/DialStore';
+
+describe('DialStore panel open state', () => {
+  it('starts collapsed when the panel registers with collapsed: true', () => {
+    const id = 'open-collapsed';
+    DialStore.registerPanel(id, id, { size: 1 }, undefined, { collapsed: true });
+
+    assert.equal(DialStore.isPanelOpen(id), false);
+    assert.equal(DialStore.getPanelOpen(id), false);
+
+    DialStore.unregisterPanel(id);
+  });
+
+  it('leaves open state unset without the option so hosts can seed their own default', () => {
+    const id = 'open-unset';
+    DialStore.registerPanel(id, id, { size: 1 });
+
+    assert.equal(DialStore.getPanelOpen(id), undefined);
+    assert.equal(DialStore.isPanelOpen(id), true);
+
+    DialStore.unregisterPanel(id);
+  });
+
+  it('sets and toggles open state, notifying subscribers', () => {
+    const id = 'open-toggle';
+    DialStore.registerPanel(id, id, { size: 1 });
+    let notifications = 0;
+    const unsubscribe = DialStore.subscribe(id, () => { notifications += 1; });
+
+    DialStore.setPanelOpen(id, false);
+    assert.equal(DialStore.isPanelOpen(id), false);
+    assert.equal(notifications, 1);
+
+    // Setting the same value is a no-op.
+    DialStore.setPanelOpen(id, false);
+    assert.equal(notifications, 1);
+
+    DialStore.togglePanelOpen(id);
+    assert.equal(DialStore.isPanelOpen(id), true);
+    assert.equal(notifications, 2);
+
+    unsubscribe();
+    DialStore.unregisterPanel(id);
+  });
+
+  it('initPanelOpen only applies while no state exists', () => {
+    const id = 'open-init';
+    DialStore.registerPanel(id, id, { size: 1 }, undefined, { collapsed: true });
+
+    DialStore.initPanelOpen(id, true);
+    assert.equal(DialStore.isPanelOpen(id), false);
+
+    DialStore.unregisterPanel(id);
+  });
+
+  it('clears open state on unregister but retains it for panels with a stable id', () => {
+    const transient = 'open-transient';
+    DialStore.registerPanel(transient, transient, { size: 1 }, undefined, { collapsed: true });
+    DialStore.unregisterPanel(transient);
+    assert.equal(DialStore.getPanelOpen(transient), undefined);
+
+    const retained = 'open-retained';
+    DialStore.registerPanel(retained, retained, { size: 1 }, undefined, { retainOnUnmount: true });
+    DialStore.setPanelOpen(retained, false);
+    DialStore.unregisterPanel(retained);
+    assert.equal(DialStore.getPanelOpen(retained), false);
+  });
+});

--- a/src/dial-store-panel-open.test.ts
+++ b/src/dial-store-panel-open.test.ts
@@ -3,9 +3,9 @@ import assert from 'node:assert/strict';
 import { DialStore } from './store/DialStore';
 
 describe('DialStore panel open state', () => {
-  it('starts collapsed when the panel registers with collapsed: true', () => {
+  it('starts collapsed when the panel registers with defaultCollapsed: true', () => {
     const id = 'open-collapsed';
-    DialStore.registerPanel(id, id, { size: 1 }, undefined, { collapsed: true });
+    DialStore.registerPanel(id, id, { size: 1 }, undefined, { defaultCollapsed: true });
 
     assert.equal(DialStore.isPanelOpen(id), false);
     assert.equal(DialStore.getPanelOpen(id), false);
@@ -47,7 +47,7 @@ describe('DialStore panel open state', () => {
 
   it('initPanelOpen only applies while no state exists', () => {
     const id = 'open-init';
-    DialStore.registerPanel(id, id, { size: 1 }, undefined, { collapsed: true });
+    DialStore.registerPanel(id, id, { size: 1 }, undefined, { defaultCollapsed: true });
 
     DialStore.initPanelOpen(id, true);
     assert.equal(DialStore.isPanelOpen(id), false);
@@ -57,7 +57,7 @@ describe('DialStore panel open state', () => {
 
   it('clears open state on unregister but retains it for panels with a stable id', () => {
     const transient = 'open-transient';
-    DialStore.registerPanel(transient, transient, { size: 1 }, undefined, { collapsed: true });
+    DialStore.registerPanel(transient, transient, { size: 1 }, undefined, { defaultCollapsed: true });
     DialStore.unregisterPanel(transient);
     assert.equal(DialStore.getPanelOpen(transient), undefined);
 

--- a/src/hooks/useDialKit.ts
+++ b/src/hooks/useDialKit.ts
@@ -15,6 +15,7 @@ export interface UseDialOptions {
   persist?: DialKitPersistOptions;
   onAction?: (action: string) => void;
   shortcuts?: Record<string, ShortcutConfig>;
+  collapsed?: boolean;
 }
 
 export interface DialKitController<T extends DialConfig> {
@@ -42,6 +43,7 @@ export function useDialKitController<T extends DialConfig>(
     id: options?.id,
     persist: options?.persist,
     shortcuts: options?.shortcuts,
+    collapsed: options?.collapsed,
   });
 
   const configRef = useRef(config);

--- a/src/hooks/useDialKit.ts
+++ b/src/hooks/useDialKit.ts
@@ -15,7 +15,7 @@ export interface UseDialOptions {
   persist?: DialKitPersistOptions;
   onAction?: (action: string) => void;
   shortcuts?: Record<string, ShortcutConfig>;
-  collapsed?: boolean;
+  defaultCollapsed?: boolean;
 }
 
 export interface DialKitController<T extends DialConfig> {
@@ -43,7 +43,7 @@ export function useDialKitController<T extends DialConfig>(
     id: options?.id,
     persist: options?.persist,
     shortcuts: options?.shortcuts,
-    collapsed: options?.collapsed,
+    defaultCollapsed: options?.defaultCollapsed,
   });
 
   const configRef = useRef(config);

--- a/src/hooks/useDialStorePanel.ts
+++ b/src/hooks/useDialStorePanel.ts
@@ -7,6 +7,7 @@ export interface UseDialStorePanelOptions {
   persist?: DialKitPersistOptions;
   shortcuts?: Record<string, ShortcutConfig>;
   kind?: 'timeline';
+  collapsed?: boolean;
 }
 
 // Serialize with a referential short-circuit: consumers can re-render at 60Hz
@@ -49,6 +50,7 @@ export function useDialStorePanel(
       retainOnUnmount: hasStableId,
       persist: optionsRef.current.persist,
       kind: optionsRef.current.kind,
+      collapsed: optionsRef.current.collapsed,
     });
     return () => DialStore.unregisterPanel(panelId);
   }, [hasStableId, panelId, name]);

--- a/src/hooks/useDialStorePanel.ts
+++ b/src/hooks/useDialStorePanel.ts
@@ -7,7 +7,7 @@ export interface UseDialStorePanelOptions {
   persist?: DialKitPersistOptions;
   shortcuts?: Record<string, ShortcutConfig>;
   kind?: 'timeline';
-  collapsed?: boolean;
+  defaultCollapsed?: boolean;
 }
 
 // Serialize with a referential short-circuit: consumers can re-render at 60Hz
@@ -50,7 +50,7 @@ export function useDialStorePanel(
       retainOnUnmount: hasStableId,
       persist: optionsRef.current.persist,
       kind: optionsRef.current.kind,
-      collapsed: optionsRef.current.collapsed,
+      defaultCollapsed: optionsRef.current.defaultCollapsed,
     });
     return () => DialStore.unregisterPanel(panelId);
   }, [hasStableId, panelId, name]);

--- a/src/solid/components/DialRoot.tsx
+++ b/src/solid/components/DialRoot.tsx
@@ -71,17 +71,16 @@ function DialRootInner(props: DialRootProps) {
 
   onMount(() => setMounted(true));
 
-  // Open state is lifted from the panels/root folder via onOpenChange
-  // callbacks (this replaces the old data-collapsed MutationObserver).
-  // Panels that have not reported yet fall back to defaultOpen.
+  // Panels report through onOpenChange (this replaces the old data-collapsed
+  // MutationObserver); their open state itself lives in the store.
   const fallbackOpen = () => inline() || (props.defaultOpen ?? true);
-  const panelOpenStates = new Map<string, boolean>();
   let rootFolderOpen: boolean | undefined;
+  let reportedOpen: boolean | undefined;
 
   const anyOpen = () => {
     const list = panels();
     if (list.length > 1) return rootFolderOpen ?? fallbackOpen();
-    return list.some((panel) => panelOpenStates.get(panel.id) ?? fallbackOpen());
+    return list.some((panel) => DialStore.getPanelOpen(panel.id) ?? fallbackOpen());
   };
 
   // On collapse/expand: swap the drag offset between the expanded panel and
@@ -106,23 +105,17 @@ function DialRootInner(props: DialRootProps) {
     }
   };
 
-  const reactToOpenChange = (before: boolean) => {
+  const reactToOpenChange = () => {
     const after = anyOpen();
-    if (after === before) return;
+    if (after === reportedOpen) return;
+    reportedOpen = after;
     applyDragOffsetForOpen(after);
     props.onOpenChange?.(after);
   };
 
-  const handlePanelOpenChange = (panelId: string, open: boolean) => {
-    const before = anyOpen();
-    panelOpenStates.set(panelId, open);
-    reactToOpenChange(before);
-  };
-
   const handleRootOpenChange = (open: boolean) => {
-    const before = anyOpen();
     rootFolderOpen = open;
-    reactToOpenChange(before);
+    reactToOpenChange();
   };
 
   const handlePointerDown = (event: PointerEvent) => {
@@ -225,7 +218,7 @@ function DialRootInner(props: DialRootProps) {
                     defaultOpen={fallbackOpen()}
                     inline={inline()}
                     toolbarExtra={timelineToggle()}
-                    onOpenChange={(open) => handlePanelOpenChange(panel.id, open)}
+                    onOpenChange={reactToOpenChange}
                   />
                 )}
               </For>

--- a/src/solid/components/Folder.tsx
+++ b/src/solid/components/Folder.tsx
@@ -1,4 +1,4 @@
-import { createSignal, createEffect, on, onCleanup, Show, JSX } from 'solid-js';
+import { createSignal, createEffect, on, onCleanup, untrack, Show, JSX } from 'solid-js';
 import { animate } from 'motion';
 import { ICON_CHEVRON } from '../../icons';
 import type { AnimationHandle } from '../primitives';
@@ -8,6 +8,7 @@ interface FolderProps {
   title: string;
   children: JSX.Element;
   defaultOpen?: boolean;
+  open?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   /** @deprecated Use RootPanel instead; kept for backwards compatibility. */
   isRoot?: boolean;
@@ -28,9 +29,10 @@ export function Folder(props: FolderProps) {
     return <RootPanel {...props} />;
   }
 
-  const [isOpen, setIsOpen] = createSignal(props.defaultOpen ?? true);
-  const [contentMounted, setContentMounted] = createSignal(props.defaultOpen ?? true);
-  let skipFirstAnim = props.defaultOpen ?? true;
+  const initialOpen = props.open ?? props.defaultOpen ?? true;
+  const [isOpen, setIsOpen] = createSignal(initialOpen);
+  const [contentMounted, setContentMounted] = createSignal(initialOpen);
+  let skipFirstAnim = initialOpen;
   let sectionContentRef: HTMLDivElement | undefined;
   let sectionAnim: AnimationHandle | null = null;
   let chevronRef: SVGSVGElement | undefined;
@@ -52,8 +54,7 @@ export function Folder(props: FolderProps) {
     );
   }, { defer: true }));
 
-  const handleToggle = () => {
-    const next = !isOpen();
+  const applyOpen = (next: boolean) => {
     setIsOpen(next);
     if (next) {
       sectionAnim?.stop();
@@ -93,6 +94,17 @@ export function Folder(props: FolderProps) {
     } else {
       setContentMounted(false);
     }
+  };
+
+  // Controlled mode: the parent owns the state, so mirror it into the animation.
+  createEffect(() => {
+    const controlled = props.open;
+    if (controlled !== undefined && controlled !== untrack(isOpen)) applyOpen(controlled);
+  });
+
+  const handleToggle = () => {
+    const next = !isOpen();
+    if (props.open === undefined) applyOpen(next);
     props.onOpenChange?.(next);
   };
 
@@ -113,7 +125,7 @@ export function Folder(props: FolderProps) {
             stroke-width="2.5"
             stroke-linecap="round"
             stroke-linejoin="round"
-            style={{ transform: `rotate(${(props.defaultOpen ?? true) ? 0 : 180}deg)` }}
+            style={{ transform: `rotate(${initialOpen ? 0 : 180}deg)` }}
           >
             <path d={ICON_CHEVRON} />
           </svg>

--- a/src/solid/components/Panel.tsx
+++ b/src/solid/components/Panel.tsx
@@ -33,6 +33,9 @@ export function Panel(props: PanelProps) {
   );
   const [presets, setPresets] = createSignal(DialStore.getPresets(props.panel.id));
   const [activePresetId, setActivePresetId] = createSignal(DialStore.getActivePresetId(props.panel.id));
+  // The store owns open/collapsed state so it can be driven programmatically.
+  const [storeOpen, setStoreOpen] = createSignal(DialStore.getPanelOpen(props.panel.id));
+  const isOpen = () => storeOpen() ?? props.defaultOpen ?? true;
   let addButtonRef!: HTMLButtonElement;
   let copyButtonRef!: HTMLButtonElement;
   let copyClipboardIconRef!: HTMLSpanElement;
@@ -50,8 +53,10 @@ export function Panel(props: PanelProps) {
         setValues(DialStore.getValues(props.panel.id));
         setPresets(DialStore.getPresets(props.panel.id));
         setActivePresetId(DialStore.getActivePresetId(props.panel.id));
+        setStoreOpen(DialStore.getPanelOpen(props.panel.id));
       });
     });
+    DialStore.initPanelOpen(props.panel.id, props.defaultOpen ?? true);
     onCleanup(unsub);
   });
 
@@ -120,6 +125,7 @@ export function Panel(props: PanelProps) {
   };
 
   const handleOpenChange = (open: boolean) => {
+    DialStore.setPanelOpen(props.panel.id, open);
     props.onOpenChange?.(open);
   };
 
@@ -308,7 +314,7 @@ export function Panel(props: PanelProps) {
 
   if (props.variant === 'section') {
     return (
-      <Folder title={props.panel.name} defaultOpen={props.defaultOpen ?? true} onOpenChange={handleOpenChange}>
+      <Folder title={props.panel.name} open={isOpen()} onOpenChange={handleOpenChange}>
         <div class="dialkit-panel-section-toolbar" onClick={(e) => e.stopPropagation()}>
           {toolbar}
         </div>
@@ -319,7 +325,7 @@ export function Panel(props: PanelProps) {
 
   return (
     <div class="dialkit-panel-wrapper">
-      <RootPanel title={props.panel.name} defaultOpen={props.defaultOpen ?? true} inline={props.inline ?? false} onOpenChange={handleOpenChange} toolbar={toolbar}>
+      <RootPanel title={props.panel.name} open={isOpen()} inline={props.inline ?? false} onOpenChange={handleOpenChange} toolbar={toolbar}>
         {renderControls()}
       </RootPanel>
     </div>

--- a/src/solid/components/RootPanel.tsx
+++ b/src/solid/components/RootPanel.tsx
@@ -8,6 +8,7 @@ export interface RootPanelProps {
   title: string;
   children: JSX.Element;
   defaultOpen?: boolean;
+  open?: boolean;
   inline?: boolean;
   onOpenChange?: (isOpen: boolean) => void;
   toolbar?: JSX.Element;
@@ -26,15 +27,21 @@ export function RootPanel(props: RootPanelProps) {
   // configuration (DialRoot never changes mode at runtime).
   const inline = props.inline ?? false;
 
-  const [isOpen, setIsOpen] = createSignal(props.defaultOpen ?? true);
+  const [isOpen, setIsOpen] = createSignal(props.open ?? props.defaultOpen ?? true);
   const [contentHeight, setContentHeight] = createSignal<number | undefined>(undefined);
   const [windowHeight, setWindowHeight] = createSignal(isServer ? 800 : window.innerHeight);
   let folderRef: HTMLDivElement | undefined;
 
+  // Controlled mode: the parent owns the state, so mirror it into the morph.
+  createEffect(() => {
+    const controlled = props.open;
+    if (controlled !== undefined) setIsOpen(controlled);
+  });
+
   const handleToggle = () => {
     if (inline) return;
     const next = !isOpen();
-    setIsOpen(next);
+    if (props.open === undefined) setIsOpen(next);
     props.onOpenChange?.(next);
   };
 

--- a/src/solid/createDialKit.ts
+++ b/src/solid/createDialKit.ts
@@ -16,6 +16,7 @@ export interface CreateDialOptions {
   persist?: DialKitPersistOptions;
   onAction?: (action: string) => void;
   shortcuts?: Record<string, ShortcutConfig>;
+  collapsed?: boolean;
 }
 
 export interface DialKitController<T extends DialConfig> {
@@ -63,6 +64,7 @@ export function createDialKitController<T extends DialConfig>(
     DialStore.registerPanel(panelId, name, config, options?.shortcuts, {
       retainOnUnmount: hasStableId,
       persist: options?.persist,
+      collapsed: options?.collapsed,
     });
 
     const unsubActions = options?.onAction

--- a/src/solid/createDialKit.ts
+++ b/src/solid/createDialKit.ts
@@ -16,7 +16,7 @@ export interface CreateDialOptions {
   persist?: DialKitPersistOptions;
   onAction?: (action: string) => void;
   shortcuts?: Record<string, ShortcutConfig>;
-  collapsed?: boolean;
+  defaultCollapsed?: boolean;
 }
 
 export interface DialKitController<T extends DialConfig> {
@@ -64,7 +64,7 @@ export function createDialKitController<T extends DialConfig>(
     DialStore.registerPanel(panelId, name, config, options?.shortcuts, {
       retainOnUnmount: hasStableId,
       persist: options?.persist,
-      collapsed: options?.collapsed,
+      defaultCollapsed: options?.defaultCollapsed,
     });
 
     const unsubActions = options?.onAction

--- a/src/store/DialStore.ts
+++ b/src/store/DialStore.ts
@@ -129,6 +129,7 @@ export type DialStorePanelOptions = {
   retainOnUnmount?: boolean;
   persist?: DialKitPersistOptions;
   kind?: 'timeline';
+  collapsed?: boolean;
 };
 
 type PersistConfig = {
@@ -321,6 +322,8 @@ class DialStoreClass {
   private registrationCounts: Map<string, number> = new Map();
   private retainedPanels: Set<string> = new Set();
   private persistConfigs: Map<string, PersistConfig> = new Map();
+  // Unset until a `collapsed` option or a host component seeds a default.
+  private panelOpen: Map<string, boolean> = new Map();
 
   registerPanel(id: string, name: string, config: DialConfig, shortcuts?: Record<string, ShortcutConfig>, options: DialStorePanelOptions = {}): void {
     const existingPanel = this.panels.get(id);
@@ -331,6 +334,9 @@ class DialStoreClass {
       );
     }
     this.configurePanelRetention(id, options);
+    if (options.collapsed !== undefined) {
+      this.initPanelOpen(id, !options.collapsed);
+    }
     this.registrationCounts.set(id, (this.registrationCounts.get(id) ?? 0) + 1);
 
     const controls = this.parseConfig(config, '', shortcuts);
@@ -417,6 +423,7 @@ class DialStoreClass {
     if (this.actionListeners.get(id)?.size === 0) this.actionListeners.delete(id);
 
     if (!this.retainedPanels.has(id)) {
+      this.panelOpen.delete(id);
       this.snapshots.delete(id);
       this.baseValues.delete(id);
       this.defaultValues.delete(id);
@@ -529,6 +536,31 @@ class DialStoreClass {
     // Return the snapshot for useSyncExternalStore compatibility
     // Use stable EMPTY_VALUES to avoid infinite loop in React 19
     return this.snapshots.get(panelId) ?? EMPTY_VALUES;
+  }
+
+  setPanelOpen(panelId: string, open: boolean): void {
+    if (this.panelOpen.get(panelId) === open) return;
+    this.panelOpen.set(panelId, open);
+    this.notify(panelId);
+  }
+
+  togglePanelOpen(panelId: string): void {
+    this.setPanelOpen(panelId, !this.isPanelOpen(panelId));
+  }
+
+  isPanelOpen(panelId: string): boolean {
+    return this.panelOpen.get(panelId) ?? true;
+  }
+
+  getPanelOpen(panelId: string): boolean | undefined {
+    return this.panelOpen.get(panelId);
+  }
+
+  /** Applies a host component's own default; no-op once the panel has state. */
+  initPanelOpen(panelId: string, open: boolean): void {
+    if (this.panelOpen.has(panelId)) return;
+    this.panelOpen.set(panelId, open);
+    this.notify(panelId);
   }
 
   getPanels(kind?: 'panel' | 'timeline'): PanelConfig[] {

--- a/src/store/DialStore.ts
+++ b/src/store/DialStore.ts
@@ -129,7 +129,7 @@ export type DialStorePanelOptions = {
   retainOnUnmount?: boolean;
   persist?: DialKitPersistOptions;
   kind?: 'timeline';
-  collapsed?: boolean;
+  defaultCollapsed?: boolean;
 };
 
 type PersistConfig = {
@@ -322,7 +322,7 @@ class DialStoreClass {
   private registrationCounts: Map<string, number> = new Map();
   private retainedPanels: Set<string> = new Set();
   private persistConfigs: Map<string, PersistConfig> = new Map();
-  // Unset until a `collapsed` option or a host component seeds a default.
+  // Unset until a `defaultCollapsed` option or a host component seeds a default.
   private panelOpen: Map<string, boolean> = new Map();
 
   registerPanel(id: string, name: string, config: DialConfig, shortcuts?: Record<string, ShortcutConfig>, options: DialStorePanelOptions = {}): void {
@@ -334,8 +334,8 @@ class DialStoreClass {
       );
     }
     this.configurePanelRetention(id, options);
-    if (options.collapsed !== undefined) {
-      this.initPanelOpen(id, !options.collapsed);
+    if (options.defaultCollapsed !== undefined) {
+      this.initPanelOpen(id, !options.defaultCollapsed);
     }
     this.registrationCounts.set(id, (this.registrationCounts.get(id) ?? 0) + 1);
 

--- a/src/svelte/components/DialRoot.svelte
+++ b/src/svelte/components/DialRoot.svelte
@@ -54,7 +54,6 @@
   let dragStart: PanelDragStart | null = null;
   let didDrag = false;
   let dragTarget: HTMLElement | null = null;
-  let panelOpenStates = new Map<string, boolean>();
   let rootOpen: boolean | undefined;
 
   const dragStyle = $derived(
@@ -97,12 +96,7 @@
 
   $effect(() => {
     const fallbackOpen = inline || defaultOpen;
-    const nextStates = new Map<string, boolean>();
-    for (const panel of panels) {
-      nextStates.set(panel.id, panelOpenStates.get(panel.id) ?? fallbackOpen);
-    }
-    panelOpenStates = nextStates;
-    rootOpen = Array.from(nextStates.values()).some(Boolean);
+    rootOpen = panels.some((panel) => DialStore.getPanelOpen(panel.id) ?? fallbackOpen);
   });
 
   $effect(() => {
@@ -174,16 +168,10 @@
     dragTarget = null;
   }
 
-  function handlePanelOpenChange(panelId: string, open: boolean) {
-    panelOpenStates.set(panelId, open);
+  // Sections write their own state to the store, so re-derive from it.
+  function handleSectionOpenChange() {
     const fallbackOpen = inline || defaultOpen;
-    const nextRootOpen = panels.some((panel) => (
-      panelOpenStates.get(panel.id) ?? fallbackOpen
-    ));
-
-    if (rootOpen === nextRootOpen) return;
-    rootOpen = nextRootOpen;
-    onOpenChange?.(nextRootOpen);
+    handleRootOpenChange(panels.some((panel) => DialStore.getPanelOpen(panel.id) ?? fallbackOpen));
   }
 
   function handleRootOpenChange(open: boolean) {
@@ -262,7 +250,7 @@
                 defaultOpen={inline || defaultOpen}
                 {inline}
                 toolbarExtra={timelineToolbar}
-                onOpenChange={(open) => handlePanelOpenChange(panel.id, open)}
+                onOpenChange={handleSectionOpenChange}
               />
             {/each}
           {/if}

--- a/src/svelte/components/Folder.svelte
+++ b/src/svelte/components/Folder.svelte
@@ -8,6 +8,7 @@
   let {
     title,
     defaultOpen = true,
+    open,
     isRoot = false,
     inline = false,
     onOpenChange,
@@ -17,6 +18,7 @@
   } = $props<{
     title: string;
     defaultOpen?: boolean;
+      open?: boolean;
     isRoot?: boolean;
     inline?: boolean;
     onOpenChange?: (isOpen: boolean) => void;
@@ -25,10 +27,12 @@
     children?: Snippet;
   }>();
 
-  let isOpen = $state(defaultOpen);
-  let isCollapsed = $state(!defaultOpen);
+  const initialOpen = open ?? defaultOpen;
+  let uncontrolledOpen = $state(defaultOpen);
+  const isOpen = $derived(open ?? uncontrolledOpen);
+  const isCollapsed = $derived(!isOpen);
   let contentHeight = $state<number | undefined>(undefined);
-  let hasInitializedRootSize = $state(!isRoot || !defaultOpen);
+  let hasInitializedRootSize = $state(!isRoot || !initialOpen);
 
   let contentRef: HTMLDivElement | undefined;
   let panelRef: HTMLDivElement | undefined;
@@ -41,10 +45,10 @@
     return () => window.removeEventListener('resize', onResize);
   });
 
-  const chevronRotation = new Spring(defaultOpen ? 0 : 180, { stiffness: 0.2, damping: 0.6 });
-  const panelWidth = new Spring(defaultOpen ? 280 : 42, { stiffness: 0.2, damping: 0.62 });
-  const panelHeight = new Spring(defaultOpen ? 220 : 42, { stiffness: 0.2, damping: 0.62 });
-  const panelRadius = new Spring(defaultOpen ? 14 : 21, { stiffness: 0.2, damping: 0.62 });
+  const chevronRotation = new Spring(initialOpen ? 0 : 180, { stiffness: 0.2, damping: 0.6 });
+  const panelWidth = new Spring(initialOpen ? 280 : 42, { stiffness: 0.2, damping: 0.62 });
+  const panelHeight = new Spring(initialOpen ? 220 : 42, { stiffness: 0.2, damping: 0.62 });
+  const panelRadius = new Spring(initialOpen ? 14 : 21, { stiffness: 0.2, damping: 0.62 });
   const panelScale = new Spring(1, { stiffness: 0.25, damping: 0.7 });
 
   $effect(() => {
@@ -84,7 +88,7 @@
     panelHeight.set(nextHeight, springOptions);
     panelRadius.set(isOpen ? 14 : 21, springOptions);
 
-    if (isOpen || !defaultOpen) {
+    if (isOpen || !initialOpen) {
       hasInitializedRootSize = true;
     }
   });
@@ -92,8 +96,7 @@
   const handleToggle = () => {
     if (inline && isRoot) return;
     const next = !isOpen;
-    isOpen = next;
-    isCollapsed = !next;
+    if (open === undefined) uncontrolledOpen = next;
     onOpenChange?.(next);
   };
 

--- a/src/svelte/components/Panel.svelte
+++ b/src/svelte/components/Panel.svelte
@@ -21,7 +21,9 @@
   const hasShortcuts = $derived(Object.keys(panel.shortcuts).length > 0);
 
   let copied = $state(false);
-  let isPanelOpen = $state(defaultOpen);
+  // The store owns open/collapsed state so it can be driven programmatically.
+  let storeOpen = $state<boolean | undefined>(DialStore.getPanelOpen(panel.id));
+  const isOpen = $derived(storeOpen ?? defaultOpen);
   let values = $state<Record<string, DialValue>>(DialStore.getValues(panel.id));
   let presets = $state<Preset[]>(DialStore.getPresets(panel.id));
   let activePresetId = $state<string | null>(DialStore.getActivePresetId(panel.id));
@@ -40,7 +42,9 @@
       values = DialStore.getValues(panel.id);
       presets = DialStore.getPresets(panel.id);
       activePresetId = DialStore.getActivePresetId(panel.id);
+      storeOpen = DialStore.getPanelOpen(panel.id);
     });
+    DialStore.initPanelOpen(panel.id, defaultOpen);
 
     return () => {
       unsub();
@@ -82,7 +86,7 @@
   };
 
   const handleOpenChange = (open: boolean) => {
-    isPanelOpen = open;
+    DialStore.setPanelOpen(panel.id, open);
     onOpenChange?.(open);
   };
 </script>
@@ -163,7 +167,7 @@
 {/snippet}
 
 {#if variant === 'section'}
-  <Folder title={panel.name} {defaultOpen} onOpenChange={handleOpenChange}>
+  <Folder title={panel.name} open={isOpen} onOpenChange={handleOpenChange}>
     <div class="dialkit-panel-section-toolbar" onclick={(e) => e.stopPropagation()}>
       {@render panelToolbar()}
     </div>
@@ -171,7 +175,7 @@
   </Folder>
 {:else}
   <div class="dialkit-panel-wrapper">
-    <Folder title={panel.name} {defaultOpen} isRoot={true} {inline} onOpenChange={handleOpenChange}>
+    <Folder title={panel.name} open={isOpen} isRoot={true} {inline} onOpenChange={handleOpenChange}>
       {#snippet toolbar()}
         {@render panelToolbar()}
       {/snippet}

--- a/src/svelte/createDialKit.svelte.ts
+++ b/src/svelte/createDialKit.svelte.ts
@@ -19,6 +19,7 @@ export interface CreateDialOptions {
   persist?: DialKitPersistOptions;
   onAction?: (action: string) => void;
   shortcuts?: Record<string, ShortcutConfig>;
+  collapsed?: boolean;
 }
 
 export type DialKitValues<T> = T;
@@ -56,6 +57,7 @@ export function createDialKitController<T extends DialConfig>(
     DialStore.registerPanel(panelId, name, config, options?.shortcuts, {
       retainOnUnmount: hasStableId,
       persist: options?.persist,
+      collapsed: options?.collapsed,
     });
     values = resolve();
 

--- a/src/svelte/createDialKit.svelte.ts
+++ b/src/svelte/createDialKit.svelte.ts
@@ -19,7 +19,7 @@ export interface CreateDialOptions {
   persist?: DialKitPersistOptions;
   onAction?: (action: string) => void;
   shortcuts?: Record<string, ShortcutConfig>;
-  collapsed?: boolean;
+  defaultCollapsed?: boolean;
 }
 
 export type DialKitValues<T> = T;
@@ -57,7 +57,7 @@ export function createDialKitController<T extends DialConfig>(
     DialStore.registerPanel(panelId, name, config, options?.shortcuts, {
       retainOnUnmount: hasStableId,
       persist: options?.persist,
-      collapsed: options?.collapsed,
+      defaultCollapsed: options?.defaultCollapsed,
     });
     values = resolve();
 

--- a/src/vue/components/DialRoot.ts
+++ b/src/vue/components/DialRoot.ts
@@ -70,17 +70,15 @@ export const DialRoot = defineComponent({
     let dragStart: PanelDragStart | null = null;
     let didDrag = false;
     let dragTarget: HTMLElement | null = null;
-    let panelOpenStates = new Map<string, boolean>();
     let rootOpen: boolean | undefined;
 
-    const syncPanelOpenStates = () => {
+    const resolveRootOpen = () => {
       const fallbackOpen = props.mode === 'inline' || props.defaultOpen;
-      const nextStates = new Map<string, boolean>();
-      for (const panel of panels.value) {
-        nextStates.set(panel.id, panelOpenStates.get(panel.id) ?? fallbackOpen);
-      }
-      panelOpenStates = nextStates;
-      rootOpen = Array.from(nextStates.values()).some(Boolean);
+      return panels.value.some((panel) => DialStore.getPanelOpen(panel.id) ?? fallbackOpen);
+    };
+
+    const syncPanelOpenStates = () => {
+      rootOpen = resolveRootOpen();
     };
 
     const connectObserver = () => {
@@ -152,22 +150,15 @@ export const DialRoot = defineComponent({
       dragTarget = null;
     };
 
-    const handlePanelOpenChange = (panelId: string, open: boolean) => {
-      panelOpenStates.set(panelId, open);
-      const fallbackOpen = props.mode === 'inline' || props.defaultOpen;
-      const nextRootOpen = panels.value.some((panel) => (
-        panelOpenStates.get(panel.id) ?? fallbackOpen
-      ));
-
-      if (rootOpen === nextRootOpen) return;
-      rootOpen = nextRootOpen;
-      emit('openChange', nextRootOpen);
-    };
-
     const handleRootOpenChange = (open: boolean) => {
       if (rootOpen === open) return;
       rootOpen = open;
       emit('openChange', open);
+    };
+
+    // Sections write their own state to the store, so re-derive from it.
+    const handleSectionOpenChange = () => {
+      handleRootOpenChange(resolveRootOpen());
     };
 
     const getDragStyle = () => dragOffset.value
@@ -243,7 +234,7 @@ export const DialRoot = defineComponent({
         defaultOpen: props.mode === 'inline' || props.defaultOpen,
         inline: props.mode === 'inline',
         toolbarExtra: timelineToggle,
-        onOpenChange: (open: boolean) => handlePanelOpenChange(panel.id, open),
+        onOpenChange: handleSectionOpenChange,
       }));
     };
 

--- a/src/vue/components/Folder.ts
+++ b/src/vue/components/Folder.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h, onMounted, onUnmounted, ref, type PropType, type VNodeChild } from 'vue';
+import { computed, defineComponent, h, onMounted, onUnmounted, ref, type PropType, type VNodeChild } from 'vue';
 import { AnimatePresence, motion } from 'motion-v';
 import { ICON_CHEVRON, ICON_PANEL } from '../../icons';
 
@@ -7,6 +7,7 @@ export const Folder = defineComponent({
   props: {
     title: { type: String, required: true },
     defaultOpen: { type: Boolean, default: true },
+      open: { type: Boolean as unknown as PropType<boolean | undefined>, default: undefined },
     isRoot: { type: Boolean, default: false },
     inline: { type: Boolean, default: false },
     toolbar: {
@@ -21,8 +22,8 @@ export const Folder = defineComponent({
   },
   emits: ['openChange'],
   setup(props, { emit, slots }) {
-    const isOpen = ref(props.defaultOpen);
-    const isCollapsed = ref(!props.defaultOpen);
+    const uncontrolledOpen = ref(props.defaultOpen);
+    const isOpen = computed(() => props.open ?? uncontrolledOpen.value);
     const contentRef = ref<HTMLElement | null>(null);
     const contentHeight = ref<number | undefined>(undefined);
     const windowHeight = ref(typeof window !== 'undefined' ? window.innerHeight : 800);
@@ -40,8 +41,7 @@ export const Folder = defineComponent({
     const handleToggle = () => {
       if (props.inline && props.isRoot) return;
       const next = !isOpen.value;
-      isOpen.value = next;
-      isCollapsed.value = !next;
+      if (props.open === undefined) uncontrolledOpen.value = next;
       emit('openChange', next);
     };
 
@@ -177,7 +177,7 @@ export const Folder = defineComponent({
           class: 'dialkit-panel-inner',
           style: panelStyle,
           onClick: !isOpen.value ? handleToggle : undefined,
-          'data-collapsed': String(isCollapsed.value),
+          'data-collapsed': String(!isOpen.value),
           whilePress: !isOpen.value ? { scale: 0.9 } : undefined,
           transition: { type: 'spring', visualDuration: 0.15, bounce: 0.3 },
         }, [folderContent()]);

--- a/src/vue/components/Folder.ts
+++ b/src/vue/components/Folder.ts
@@ -7,7 +7,7 @@ export const Folder = defineComponent({
   props: {
     title: { type: String, required: true },
     defaultOpen: { type: Boolean, default: true },
-      open: { type: Boolean as unknown as PropType<boolean | undefined>, default: undefined },
+    open: { type: Boolean as unknown as PropType<boolean | undefined>, default: undefined },
     isRoot: { type: Boolean, default: false },
     inline: { type: Boolean, default: false },
     toolbar: {

--- a/src/vue/components/Panel.ts
+++ b/src/vue/components/Panel.ts
@@ -1,4 +1,4 @@
-import { Fragment, defineComponent, h, onMounted, onUnmounted, ref, type PropType, type VNodeChild } from 'vue';
+import { Fragment, computed, defineComponent, h, onMounted, onUnmounted, ref, type PropType, type VNodeChild } from 'vue';
 import { AnimatePresence, motion } from 'motion-v';
 import { ICON_ADD_PRESET, ICON_CHECK, ICON_CLIPBOARD } from '../../icons';
 import { DialStore } from '../../store/DialStore';
@@ -43,6 +43,9 @@ export const Panel = defineComponent({
     const presets = ref(DialStore.getPresets(props.panel.id));
     const activePresetId = ref<string | null>(DialStore.getActivePresetId(props.panel.id));
     const copied = ref(false);
+    const storeOpen = ref<boolean | undefined>(DialStore.getPanelOpen(props.panel.id));
+    // The store owns open/collapsed state so it can be driven programmatically.
+    const isOpen = computed(() => storeOpen.value ?? props.defaultOpen);
     const hasShortcuts = () => Object.keys(DialStore.getPanel(props.panel.id)?.shortcuts ?? {}).length > 0;
 
     let unsubscribe: (() => void) | undefined;
@@ -53,7 +56,9 @@ export const Panel = defineComponent({
         values.value = DialStore.getValues(props.panel.id);
         presets.value = DialStore.getPresets(props.panel.id);
         activePresetId.value = DialStore.getActivePresetId(props.panel.id);
+        storeOpen.value = DialStore.getPanelOpen(props.panel.id);
       });
+      DialStore.initPanelOpen(props.panel.id, props.defaultOpen);
     });
 
     onUnmounted(() => {
@@ -90,6 +95,7 @@ export const Panel = defineComponent({
     };
 
     const handleOpenChange = (open: boolean) => {
+      DialStore.setPanelOpen(props.panel.id, open);
       emit('openChange', open);
     };
 
@@ -270,7 +276,7 @@ export const Panel = defineComponent({
       if (props.variant === 'section') {
         return h(Folder, {
           title: props.panel.name,
-          defaultOpen: props.defaultOpen,
+          open: isOpen.value,
           onOpenChange: handleOpenChange,
         }, {
           default: () => [
@@ -286,7 +292,7 @@ export const Panel = defineComponent({
       return h('div', { class: 'dialkit-panel-wrapper' }, [
         h(Folder, {
           title: props.panel.name,
-          defaultOpen: props.defaultOpen,
+          open: isOpen.value,
           isRoot: true,
           inline: props.inline,
           toolbar: () => toolbarNode,

--- a/src/vue/useDialKit.ts
+++ b/src/vue/useDialKit.ts
@@ -14,6 +14,7 @@ export interface UseDialOptions {
   persist?: DialKitPersistOptions;
   onAction?: (action: string) => void;
   shortcuts?: Record<string, ShortcutConfig>;
+  collapsed?: boolean;
 }
 
 export interface DialKitController<T extends DialConfig> {
@@ -58,6 +59,7 @@ export function useDialKitController<T extends DialConfig>(
     DialStore.registerPanel(panelId, name, configRef.value, shortcutsRef.value, {
       retainOnUnmount: hasStableId,
       persist: persistRef.value,
+      collapsed: options?.collapsed,
     });
     flatValues.value = DialStore.getValues(panelId);
 

--- a/src/vue/useDialKit.ts
+++ b/src/vue/useDialKit.ts
@@ -14,7 +14,7 @@ export interface UseDialOptions {
   persist?: DialKitPersistOptions;
   onAction?: (action: string) => void;
   shortcuts?: Record<string, ShortcutConfig>;
-  collapsed?: boolean;
+  defaultCollapsed?: boolean;
 }
 
 export interface DialKitController<T extends DialConfig> {
@@ -59,7 +59,7 @@ export function useDialKitController<T extends DialConfig>(
     DialStore.registerPanel(panelId, name, configRef.value, shortcutsRef.value, {
       retainOnUnmount: hasStableId,
       persist: persistRef.value,
-      collapsed: options?.collapsed,
+      defaultCollapsed: options?.defaultCollapsed,
     });
     flatValues.value = DialStore.getValues(panelId);
 


### PR DESCRIPTION
this tackles #56.

TL;DR:
Panels now have a new setting adjacent to the `id` config option to set their open state when creating them. Also it's now possible to toggle the status from outside using the `DialStore`